### PR TITLE
Disable Command+W (and Command+Shift+W to Command+W) on Skype

### DIFF
--- a/files/prefpane/checkbox.xml
+++ b/files/prefpane/checkbox.xml
@@ -7298,6 +7298,18 @@
           </list>
         </item>
         <item>
+          <name>Enable at only Skype</name>
+          <list>
+            <item>
+              <name>Prevent accidental close of chat windows (Ignore Command+W and require Command+Shift+W to send Command+W</name>
+              <identifier>remap.app_skype_command_shift_w_to_close</identifier>
+              <only>SKYPE</only>
+              <autogen>--KeyToKey-- KeyCode::W, VK_COMMAND | VK_SHIFT, KeyCode::W, VK_COMMAND</autogen>
+              <autogen>--KeyToKey-- KeyCode::W, VK_COMMAND | ModifierFlag::NONE</autogen>
+            </item>
+          </list>
+        </item>
+        <item>
           <name>Quicksilver Mode</name>
           <list>
             <item>


### PR DESCRIPTION
Mac for Skype has no option to enable prompt when you close conversation.
And it is not easy to reopen it. (It's impossible on latest version!)

So, this configuration disables Command+W to prevent accidental closing.
