### PR TITLE
Adding PC Style Alt+F4

### DIFF
--- a/files/prefpane/checkbox.xml
+++ b/files/prefpane/checkbox.xml
@@ -8490,6 +8490,14 @@
           <autogen>--KeyToKey-- KeyCode::SHIFT_L, VK_OPTION, KeyCode::SPACE, ModifierFlag::COMMAND_L</autogen>
           <autogen>--KeyToKey-- KeyCode::SHIFT_R, VK_OPTION, KeyCode::SPACE, ModifierFlag::COMMAND_L | ModifierFlag::SHIFT_L</autogen>
         </item>
+        <item>
+          <name>Use PC Style Alt+F4</name>
+          <appendix>Disable Cmd+Q, remap Alt/Cmd+F4 to Cmd+Q</appendix>
+          <identifier>remap.pcstyle_altf4</identifier>
+          <autogen>--KeyToKey-- KeyCode::F4, VK_COMMAND, KeyCode::Q, VK_COMMAND</autogen>
+          <autogen>--KeyToKey-- KeyCode::F4, VK_OPTION, KeyCode::Q, VK_COMMAND</autogen>
+          <autogen>--KeyOverlaidModifier-- KeyCode::Q, VK_COMMAND, KeyCode::VK_NONE</autogen>
+        </item>
       </list>
     </item>
 


### PR DESCRIPTION
Adding hotkey for people used to years of quitting via alt+f4.

Also disabling cmd+q because of it's proximity to cmd+w -- alt+f4 provides a less accidentally triggered hotkey.
