### PR TITLE
Add Firefox Aurora and Chrome Canary

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -64,6 +64,7 @@
   <appdef>
     <appname>FIREFOX</appname>
     <equal>org.mozilla.firefox</equal>
+    <equal>org.mozilla.aurora</equal>
   </appdef>
 
   <appdef>
@@ -174,6 +175,7 @@
   <appdef>
     <appname>GOOGLE_CHROME</appname>
     <equal>com.google.Chrome</equal>
+    <equal>com.google.Chrome.canary</equal>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
Firefox Aurora and Chrome Canary should be detected as Firefox and Chrome.

Please consider adding them. :smile:
