### PR TITLE
Add Home Row Numbers Overlay setting

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/number.xml
+++ b/src/core/server/Resources/include/checkbox/standards/number.xml
@@ -18,15 +18,15 @@
         <autogen>--KeyToKey-- KeyCode::SEMICOLON, KeyCode::KEY_0</autogen>
       </item>
       <item>
-	<name>Hold Space+ASDFGHJKL; to 1234567890</name>
-	<identifier>remap.space_to_homerow_numbers</identifier>
+        <name>Hold Space+ASDFGHJKL; to 1234567890</name>
+        <identifier>remap.space_to_homerow_numbers</identifier>
         <autogen>--KeyOverlaidModifier-- KeyCode::SPACE, KeyCode::VK_CONFIG_SYNC_KEYDOWNUP_notsave_homerow_numbers, KeyCode::SPACE</autogen>
       </item>
       <item>
-	<name>Hold CMD_L+CMD_R+ASDFGHJKL; to 1234567890</name>
-	<identifier>remap.cmdcmd_to_homerow_numbers</identifier>
-	<autogen>--KeyToKey-- KeyCode::COMMAND_R, ModifierFlag::COMMAND_L | ModifierFlag::COMMAND_R, KeyCode::VK_CONFIG_SYNC_KEYDOWNUP_notsave_homerow_numbers</autogen>
-	<autogen>--KeyToKey-- KeyCode::COMMAND_L, ModifierFlag::COMMAND_L | ModifierFlag::COMMAND_R, KeyCode::VK_CONFIG_SYNC_KEYDOWNUP_notsave_homerow_numbers</autogen>
+        <name>Hold CMD_L+CMD_R+ASDFGHJKL; to 1234567890</name>
+        <identifier>remap.cmdcmd_to_homerow_numbers</identifier>
+        <autogen>--KeyToKey-- KeyCode::COMMAND_R, ModifierFlag::COMMAND_L | ModifierFlag::COMMAND_R, KeyCode::VK_CONFIG_SYNC_KEYDOWNUP_notsave_homerow_numbers</autogen>
+        <autogen>--KeyToKey-- KeyCode::COMMAND_L, ModifierFlag::COMMAND_L | ModifierFlag::COMMAND_R, KeyCode::VK_CONFIG_SYNC_KEYDOWNUP_notsave_homerow_numbers</autogen>
       </item>
   </item>
   <item>


### PR DESCRIPTION
I've been using this setting for a while as it's especially helpful in conjunction with the 1234567890->!@#$%^&*() setting. Note that while activated other keys will behave normally, so for example if you are holding Space and enter 3,.,1,4 it will enter 3.14 correctly (rather than 314). Also, I'm not sure if using vk_config is the best way of going about this despite its versatility.
