### PR TITLE
Add two bindings: 1. Control-j to Enter 2. jk_toggle for ubiquitous

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/control.xml
+++ b/src/core/server/Resources/include/checkbox/standards/control.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root>
-  <item>
+    <item>
     <name>Change Control_L Key (Left Control)</name>
     <item>
       <name>Control_L to Command_L</name>
@@ -242,6 +242,15 @@
       <name>Control_R to RightClick</name>
       <identifier>remap.controlR2rightclick</identifier>
       <autogen>--KeyToPointingButton-- KeyCode::CONTROL_R, PointingButton::RIGHT</autogen>
+    </item>
+    <item>
+      <name>Control-j to Enter</name>
+      <identifier>remap.controlj_return</identifier>
+      <autogen>
+        --KeyToKey--
+        KeyCode::J, VK_CONTROL,
+        KeyCode::ENTER
+      </autogen>
     </item>
   </item>
 </root>

--- a/src/core/server/Resources/include/checkbox/ubiquitous_vim_bindings/core.xml
+++ b/src/core/server/Resources/include/checkbox/ubiquitous_vim_bindings/core.xml
@@ -1076,6 +1076,19 @@
       </item>
 
       <item>
+        <name>Simultaneous jk toggles Normal Mode</name>
+        <identifier>remap.vimnormal_jk_toggle</identifier>
+        <not>{{UBIQUITOUS_VIM_BINDINGS_IGNORE_APPS}}</not>
+        <autogen>
+          --SimultaneousKeyPresses--
+          KeyCode::J, KeyCode::K,
+          KeyCode::VK_LOCK_ALL_FORCE_OFF,
+          KeyCode::VK_CONFIG_TOGGLE_notsave_ubiq_vimnormal,
+          {{ UBIQUITOUS_VIM_BINDINGS_CANCEL_OPERATOR_PENDING }}
+        </autogen>
+      </item>
+
+      <item>
         <name>Ctrl-[ toggles Normal Mode</name>
         <identifier>remap.vimnormal_ctrlbracketleft_toggle</identifier>
         <not>{{UBIQUITOUS_VIM_BINDINGS_IGNORE_APPS}}</not>


### PR DESCRIPTION
Here are two suggested bindings. I packaged them in one commit because they are basically aimed at improving the Ubiquitous experience.
1. Bind Control-j to Enter mapping.

I  am adding this in `control.xml`.
1. Toggle normal mode with simultaneous `jk`.

This went into `./ubiquitous_vim_bindings/core.xml`.

It's a **very** common binding among Vim users (myself included).

Thanks.
