### PR TITLE
Add Shift Keys to Parens

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/shift.xml
+++ b/src/core/server/Resources/include/checkbox/standards/shift.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0"?>
 <root>
   <item>
+    <name>Change Shift Keys</name>
+    <item>
+      <name>Shift to Shift</name>
+      <appendix>(+ When you type Shift only, send the appropriate parenthesis)</appendix>
+      <identifier>private.shiftparens</identifier>
+      <autogen>__KeyOverlaidModifier__ KeyCode::SHIFT_L, ModifierFlag::SHIFT_L | ModifierFlag::NONE, KeyCode::SHIFT_L, KeyCode::KEY_9, ModifierFlag::SHIFT_L</autogen>
+      <autogen>__KeyOverlaidModifier__ KeyCode::SHIFT_R, ModifierFlag::SHIFT_R | ModifierFlag::NONE, KeyCode::SHIFT_R, KeyCode::KEY_0, ModifierFlag::SHIFT_R</autogen>
+    </item>
+  </item>
+
+  <item>
     <name>Change Shift_L Key (Left Shift)</name>
     <item>
       <name>Shift_L to CapsLock</name>


### PR DESCRIPTION
This patch adds the option to remap the shift keys to the appropriate parenthesis when they are pressed without any other key, as seen in http://stevelosh.com/blog/2012/10/a-modern-space-cadet/#better-shifting

I added a new category for options pertaining to both shift keys instead of just one, not sure if that was correct.

Also, I wrote this with the stable version 7.8, but I updated the definition to match the changes I saw.
