### PR TITLE
Emacsmodeでのタブ操作について

### DIFF
--- a/src/core/server/Resources/include/checkbox/emacs_mode.xml
+++ b/src/core/server/Resources/include/checkbox/emacs_mode.xml
@@ -332,6 +332,25 @@
       <autogen>__KeyToKey__ KeyCode::W, VK_OPTION, KeyCode::W, ModifierFlag::COMMAND_L</autogen>
     </item>
     <item>
+      <name>[ex] Option+E to Command+W</name>
+      <identifier>option.emacsmode_ex_optionE</identifier>
+      <not>{{EMACS_MODE_IGNORE_APPS}}</not>
+      <autogen>__KeyToKey__ KeyCode::E, VK_OPTION, KeyCode::W, ModifierFlag::COMMAND_L</autogen>
+    </item>
+    <item>
+      <name>[ex] Option+T to Command+T</name>
+      <identifier>option.emacsmode_ex_optionT</identifier>
+      <not>{{EMACS_MODE_IGNORE_APPS}}</not>
+      <autogen>__KeyToKey__ KeyCode::T, VK_OPTION, KeyCode::T, ModifierFlag::COMMAND_L</autogen>
+    </item>
+    <item>
+      <name>[ex] Option+{|} to Command+{|}</name>
+      <identifier>option.emacsmode_ex_option_tab_change</identifier>
+      <not>{{EMACS_MODE_IGNORE_APPS}}</not>
+      <autogen>__KeyToKey__ KeyCode::JIS_BRACKET_RIGHT, VK_OPTION | VK_SHIFT, KeyCode::JIS_BRACKET_RIGHT, ModifierFlag::COMMAND_L | VK_SHIFT</autogen>
+      <autogen>__KeyToKey__ KeyCode::JIS_BRACKET_LEFT, VK_OPTION | VK_SHIFT, KeyCode::JIS_BRACKET_LEFT, ModifierFlag::COMMAND_L | VK_SHIFT</autogen>
+    </item>
+    <item>
       <name>[ex] Use Control+X as prefix key</name>
       <item>
         <!-- C-x Mode Core -->


### PR DESCRIPTION
Command+XXXを変更するものではないoption.emacsmode_ex_optionWにて、EMACS_MODE_IGNORE_APPSを欠いていたので修正させていただきました。

また、Command_RをOptionに変更している私がEmacsとTerminalでタブの操作に使っている設定を追加させていただきました。(Option+EはMeta-Wとかぶらずにタブを閉じるためです)
もしよろしければ、マージをお願いします。
