### PR TITLE
Add iTap mobile to RDC definition

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -42,6 +42,7 @@
     <equal>com.microsoft.rdc</equal>
     <equal>net.sf.cord</equal>
     <equal>com.thinomenon.RemoteDesktopConnection</equal>
+    <equal>com.itap-mobile.qmote</equal>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
I've added [iTap Mobile](http://itap-mobile.com/desktop/rdp) to the remote desktop client list.
