### PR TITLE
Fix semicolon key broken on homerow_mode.xml cleanup

### DIFF
--- a/src/core/server/Resources/include/checkbox/homerow_mode.xml
+++ b/src/core/server/Resources/include/checkbox/homerow_mode.xml
@@ -122,6 +122,7 @@
     <item>
       <name>[Option] ; to Return</name>
       <identifier>option.homerow_mode_return</identifier>
+      <config_only>notsave.homerow_mode</config_only>
       <autogen>__KeyToKey__ KeyCode::SEMICOLON, KeyCode::RETURN</autogen>
     </item>
     <item>


### PR DESCRIPTION
Forgot <config_only>notsave.homerow_mode</config_only> in one of the items
