### PR TITLE
Added a new STS identifier to appdef.xml

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -159,6 +159,7 @@
     <appname>ECLIPSE</appname>
     <equal>org.eclipse.eclipse</equal>
     <equal>com.springsource.sts</equal>
+    <equal>org.springsource.sts.ide</equal>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
Not sure of the exact version, however at least "STS 3.3.0.RELEASE - BASED ON ECLIPSE KEPLER 4.3" seems to have a new identifier: "org.springsource.sts.ide".
