### PR TITLE
add comma to dot conversion on Lithuanian keypad

### DIFF
--- a/src/core/server/Resources/checkbox.xml
+++ b/src/core/server/Resources/checkbox.xml
@@ -110,6 +110,7 @@
   <include path="include/checkbox/languages/italian.xml" />
   <include path="include/checkbox/languages/japanese.xml" />
   <include path="include/checkbox/languages/korean.xml" />
+  <include path="include/checkbox/languages/lithuanian.xml" />
   <include path="include/checkbox/languages/norwegian.xml" />
   <include path="include/checkbox/languages/russian.xml" />
   <include path="include/checkbox/languages/slovenian.xml" />

--- a/src/core/server/Resources/include/checkbox/languages/lithuanian.xml
+++ b/src/core/server/Resources/include/checkbox/languages/lithuanian.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>For Lithuanian</name>
+    <item>
+      <name>Change KeyPad Comma(,) to Dot(.)</name>
+      <identifier>remap.lithuanian_keypad_comma_to_dot</identifier>
+      <inputsource_only>LITHUANIAN</inputsource_only>
+      <autogen>__KeyToKey__ KeyCode::KEYPAD_DOT, KeyCode::DOT</autogen>
+    </item>
+  </item>
+</root>

--- a/src/core/server/Resources/inputsourcedef.xml
+++ b/src/core/server/Resources/inputsourcedef.xml
@@ -104,6 +104,12 @@
   </inputsourcedef>
 
   <inputsourcedef>
+    <name>LITHUANIAN</name>
+    <detail>LITHUANIAN</detail>
+    <inputsourceid_equal>com.apple.keylayout.Lithuanian</inputsourceid_equal>
+  </inputsourcedef>
+
+  <inputsourcedef>
     <name>NORWEGIAN</name>
     <detail>NORWEGIAN_EXTENDED</detail>
     <inputsourceid_equal>com.apple.keylayout.NorwegianExtended</inputsourceid_equal>


### PR DESCRIPTION
Hi,

This is a preset for Lithuanian keyboard to convert keypad comma to keypad dot.

Please let me know if any additional changes are needed to match the rest of code base.  Thank you.
