### PR TITLE
Add support for Dvorak mapping excluding Yubikeys

### DIFF
--- a/src/core/server/Resources/devicevendordef.xml
+++ b/src/core/server/Resources/devicevendordef.xml
@@ -114,4 +114,9 @@
     <vendorname>Riitek</vendorname>
     <vendorid>0x1997</vendorid>
   </devicevendordef>
+
+  <devicevendordef>
+    <vendorname>YUBICO</vendorname>
+    <vendorid>0x1050</vendorid>
+  </devicevendordef>
 </root>

--- a/src/core/server/Resources/include/checkbox/for_dvorak_users.xml
+++ b/src/core/server/Resources/include/checkbox/for_dvorak_users.xml
@@ -93,6 +93,15 @@
     </item>
 
     <item>
+      <name>Use Dvorak (No Yubikeys)</name>
+      <appendix>(QWERTY to Dvorak)</appendix>
+      <appendix>(ignores Yubikeys)</appendix>
+      <identifier>remap.dvorak2qwerty_qwerty2dvoraknoyubico</identifier>
+      <device_not>DeviceVendor::YUBICO</device_not>
+      <include path="snippets/dvorak.xml" />
+    </item>
+
+    <item>
       <name>Use Dvorak-Qwerty⌘</name>
       <appendix>(QWERTY to Dvorak)</appendix>
       <appendix>(+ Command+Keys to Qwerty)</appendix>


### PR DESCRIPTION
Yubikeys are a popular keyboard-based OTP solution, but they don't support the Dvorak layout, only QWERTY and AZERTY. This adds a "Dvorak->QWERTY (no Yubikeys)" option to the "For Dvorak Users" section, which will allow users to type in Dvorak, but Yubikey keypresses will show up as QWERTY to the system.
