### PR TITLE
Added Citrix Viewer to the list of exceptions for PC-Style Home/End handling

### DIFF
--- a/src/core/server/Resources/replacementdef.xml
+++ b/src/core/server/Resources/replacementdef.xml
@@ -126,13 +126,14 @@
       EMACS,
       TERMINAL,
       X11,
+      CITRIX_XEN_APP_VIEWER,
     </replacementvalue>
   </replacementdef>
 
   <replacementdef>
     <replacementname>PC_STYLE_BINDINGS_IGNORE_APPS_DESCRIPTION</replacementname>
     <replacementvalue>
-      (Except in Virtual Machine, RDC, VNC, TeamViewer, EMACS, TERMINAL, X11)
+      (Except in Virtual Machine, RDC, VNC, TeamViewer, EMACS, TERMINAL, X11, Citrix Viewer)
     </replacementvalue>
   </replacementdef>
 


### PR DESCRIPTION
Hi,

I have added Citrix Viewer to the list of exceptions for PC-Style Home/End handling. There's not much to explain, Citrix Viewer is a remote desktop access application and so it makes sense to add it to the excluded list just like any other application that is already there.

I tested the change and it works fine, i.e. when logged remotely using Citrix Viewer I can now observe proper Home/End behavior. 
