### PR TITLE
Remap Targus4Mac presenter remote

### DIFF
--- a/examples/private.targus4mac_bluetooth.xml
+++ b/examples/private.targus4mac_bluetooth.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<root>
+  <devicevendordef>
+    <vendorname>TARGUS</vendorname>
+    <vendorid>0x1048</vendorid>
+  </devicevendordef>
+  <deviceproductdef>
+    <productname>TARGUS_PRESENTER</productname>
+    <productid>0x07d1</productid>
+  </deviceproductdef>
+  <item>
+    <name>Remap Targus Presenter to work with Google Presentation</name>
+    <identifier>private.targus1</identifier>
+    <device_only>DeviceVendor::TARGUS, DeviceProduct::TARGUS_PRESENTER</device_only>
+    <autogen>__KeyToKey__ KeyCode::CURSOR_DOWN, ModifierFlag::SHIFT_L, KeyCode::CURSOR_RIGHT</autogen>
+    <autogen>__KeyToKey__ KeyCode::CURSOR_UP, ModifierFlag::SHIFT_L, KeyCode::CURSOR_LEFT</autogen>
+  </item>
+</root>


### PR DESCRIPTION
Preamble: I thought it would be good to start doing community supplied mappings for certain scenarios.  In my case it took me the better part of 1hr to figure the below issue out.

-----Commit comment-----
Google Presentations run in the browser and that caused an issue for my
Targus presenter remote for Mac.  I remapped the keys to be more
generic so they work in Keynote and GooglePresentation.
