### PR TITLE
Add "Return to Option_L" setting (with fallback to Return).

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/return.xml
+++ b/src/core/server/Resources/include/checkbox/standards/return.xml
@@ -14,6 +14,12 @@
       <autogen>__KeyOverlaidModifier__ KeyCode::RETURN, KeyCode::CONTROL_L, KeyCode::RETURN</autogen>
     </item>
     <item>
+      <name>Return to Option_L</name>
+      <appendix>(+ When you type Return only, send Return)</appendix>
+      <identifier>remap.return2optionL_return</identifier>
+      <autogen>__KeyOverlaidModifier__ KeyCode::RETURN, KeyCode::OPTION_L, KeyCode::RETURN</autogen>
+    </item>
+    <item>
       <name>Return to Control_L</name>
       <appendix>(+ When you type Return only, send Return) + [KeyRepeat]</appendix>
       <identifier>remap.return2controlL_return_keyrepeat</identifier>


### PR DESCRIPTION
Simalar to "Return to Control_L (+ When you type Return only, send Return)". Looks like a killer feature for the emacs users.
