### PR TITLE
Add Fn to Command_L *except* Function keys

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/fn.xml
+++ b/src/core/server/Resources/include/checkbox/standards/fn.xml
@@ -3,6 +3,40 @@
   <item>
     <name>Change Fn Key</name>
     <item>
+      <name>Fn+letter to Command+letter</name>
+      <identifier>remap.fnletter_to_commandletter</identifier>
+      <include path="../commons/wrap_keys/alphabet.xml">
+        <replacementdef>
+          <replacementname>BEFORE</replacementname>
+          <replacementvalue>ModifierFlag::FN</replacementvalue>
+        </replacementdef>
+        <replacementdef>
+          <replacementname>AFTER</replacementname>
+          <replacementvalue>ModifierFlag::COMMAND_L</replacementvalue>
+        </replacementdef>
+      </include>
+      <include path="../commons/wrap_keys/number.xml">
+        <replacementdef>
+          <replacementname>BEFORE</replacementname>
+          <replacementvalue>ModifierFlag::FN</replacementvalue>
+        </replacementdef>
+        <replacementdef>
+          <replacementname>AFTER</replacementname>
+          <replacementvalue>ModifierFlag::COMMAND_L</replacementvalue>
+        </replacementdef>
+      </include>
+      <include path="../commons/wrap_keys/symbol.xml">
+        <replacementdef>
+          <replacementname>BEFORE</replacementname>
+          <replacementvalue>ModifierFlag::FN</replacementvalue>
+        </replacementdef>
+        <replacementdef>
+          <replacementname>AFTER</replacementname>
+          <replacementvalue>ModifierFlag::COMMAND_L</replacementvalue>
+        </replacementdef>
+      </include>
+    </item>
+    <item>
       <name>Fn+letter to Control+letter</name>
       <appendix>Fn+Escape,Space,Tab to Control+Escape,Space,Tab</appendix>
       <appendix></appendix>


### PR DESCRIPTION
It would be nice to have a mapping from Fn to Command for all letters/numbers/symbols but NOT Function keys or Tab/Escape/Space.  This makes it easy to use a MacBook Cut/Copy/Paste like a PC without messing up the Function keys like Brightness, Volume, etc.
