### PR TITLE
add appdef: textmate2

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -17,6 +17,7 @@
   <appdef>
     <appname>TEXTMATE</appname>
     <prefix>com.macromates.textmate</prefix>
+    <prefix>com.macromates.TextMate</prefix>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
TextMate_2.0( http://macromates.com/download )からApplication Bundle Identifierが
"com.macromates.TextMate.preview"に変更されていたため
appdef.xmlに追加させていただきました
