### PR TITLE
In Terminal, swap command-L to option-L but pass through tab, backquote AND space

### DIFF
--- a/src/core/server/Resources/include/checkbox/apps/terminal.xml
+++ b/src/core/server/Resources/include/checkbox/apps/terminal.xml
@@ -32,6 +32,22 @@
       </include>
     </item>
     <item>
+      <name>Change Command_L to Option_L</name>
+      <appendix>(Pass-Through Tab, Backquote and Space)</appendix>
+      <identifier>remap.app_term_commandL2optionL_except_tab_space</identifier>
+      <only>TERMINAL</only>
+      <include path="../snippets/modifier_tab_to_command_tab_backquote_space.xml">
+        <replacementdef>
+          <replacementname>FROM_MODIFIER</replacementname>
+          <replacementvalue>COMMAND_L</replacementvalue>
+        </replacementdef>
+        <replacementdef>
+          <replacementname>TO_MODIFIER</replacementname>
+          <replacementvalue>OPTION_L</replacementvalue>
+        </replacementdef>
+      </include>
+    </item>
+    <item>
       <name>Change Delete Key</name>
       <item>
         <name>Delete to Control_L+H</name>

--- a/src/core/server/Resources/include/checkbox/snippets/modifier_tab_to_command_tab_backquote_space.xml
+++ b/src/core/server/Resources/include/checkbox/snippets/modifier_tab_to_command_tab_backquote_space.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<root>
+
+  <include path="modifier_tab_to_command_tab.xml" />
+  <include path="modifier_tab_to_command_tab_backquote.xml" />
+
+  <block>
+    <config_only>notsave.modifier_tab_to_command_tab</config_only>
+    <autogen>
+      __KeyToKey__
+      KeyCode::SPACE, ModifierFlag::{{ TO_MODIFIER }},
+      KeyCode::SPACE, ModifierFlag::COMMAND_L,
+      KeyCode::VK_LOCK_COMMAND_L_FORCE_ON, ModifierFlag::COMMAND_L,
+      KeyCode::VK_CONFIG_FORCE_ON_notsave_modifier_tab_to_command_tab_tab_mode, ModifierFlag::COMMAND_L,
+    </autogen>
+  </block>
+
+</root>


### PR DESCRIPTION
I found it useful to be able to launch quicksilver (which I have bound to cmd-space) from Terminal apps when having the 'swap command-L to option-L but passthrough tab, backquote' setting enabled.  I created this setting which also passes through space.
