### PR TITLE
vim_emu update: added S-DOT as ':' for German keyboard

### DIFF
--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
@@ -152,6 +152,11 @@
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
         KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
       </autogen>
+      <autogen>
+        __KeyToKey__ KeyCode::DOT, VK_SHIFT|ModifierFlag::NONE,
+        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
+      </autogen>
       <!-- Normal Mode: Enter Command Mode End -->
 
       <!-- Normal Mode: Save, Quit Begin -->
@@ -165,12 +170,14 @@
         VK_SHIFT|ModifierFlag::NONE,
         KeyCode::S, VK_COMMAND,
         KeyCode::W, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA2_FORCE_OFF,
         {{VIM_EMU_NORMAL_OFF}}
       </autogen>
       <autogen> <!-- Quit -->
         __KeyToKey__ KeyCode::Q, ModifierFlag::EXTRA2|
         VK_SHIFT|ModifierFlag::NONE,
         KeyCode::W, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA2_FORCE_OFF,
         {{VIM_EMU_NORMAL_OFF}}
       </autogen>
       <autogen> <!-- Escape from EXTRA2 -->
@@ -688,31 +695,46 @@
       <autogen> <!-- Save -->
         __KeyToKey__ KeyCode::RETURN, ModifierFlag::EXTRA1|ModifierFlag::NONE,
         KeyCode::S, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
         KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
       </autogen>
       <autogen> <!-- Save As -->
         __KeyToKey__ KeyCode::SPACE, ModifierFlag::EXTRA1|ModifierFlag::NONE,
         KeyCode::S, VK_SHIFT|VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+        {{VIM_EMU_EMU_OFF}},
       </autogen>
       <autogen> <!-- Save and Quit -->
         __KeyToKey__ KeyCode::Q, ModifierFlag::EXTRA1|ModifierFlag::NONE,
         KeyCode::S, VK_COMMAND,
         KeyCode::W, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+        {{VIM_EMU_EMU_OFF}},
       </autogen>
       <autogen> <!-- Quit -->
         __KeyToKey__ KeyCode::Q, ModifierFlag::NONE,
         KeyCode::W, VK_COMMAND,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+        {{VIM_EMU_EMU_OFF}},
       </autogen>
       <autogen> <!-- Help -->
         __KeyToKey__ KeyCode::H, ModifierFlag::NONE,
         KeyCode::SLASH, VK_SHIFT|VK_COMMAND,
+        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
+        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+      <autogen> <!-- Escape from Command Mode -->
+        __KeyToKey__ KeyCode::ESCAPE, ModifierFlag::EXTRA1,
+        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
+        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
+        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+      <autogen> <!-- Escape from Command Mode -->
+        __KeyToKey__ KeyCode::BRACKET_LEFT, VK_CONTROL|ModifierFlag::EXTRA1,
+        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
         KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
       </autogen>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_replacementdef.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_replacementdef.xml
@@ -15,8 +15,8 @@
   <replacementdef>
     <replacementname>VIM_EMU_FORCE_OFF_ALL_BUT_LINE</replacementname>
     <replacementvalue>
-      KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu{{VIM_EMU_ALTCONFIG}},
+      KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_visual{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_visual_line{{VIM_EMU_ALTCONFIG}},
@@ -37,8 +37,8 @@
   <replacementdef>
     <replacementname>VIM_EMU_FORCE_ON_NORMAL_MODE</replacementname>
     <replacementvalue>
-      KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu{{VIM_EMU_ALTCONFIG}},
+      KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_visual{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_visual_line{{VIM_EMU_ALTCONFIG}},
@@ -54,8 +54,8 @@
       KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_search{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_LOCK_ALL_FORCE_OFF,
       KeyCode::VK_MOUSEKEY_LOCK_BUTTON_ALL_FORCE_OFF,
-      KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu{{VIM_EMU_ALTCONFIG}},
+      KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_using{{VIM_EMU_ALTCONFIG}},
       KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
     </replacementvalue>
   </replacementdef>


### PR DESCRIPTION
Update for German keyboard: Added Shift-DOT as COLON.

Fixed save/quit for normal/command mode (cleanup VKLOCK_EXTRA)
