### PR TITLE
Add Remotix to RDC definition

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -52,6 +52,7 @@
     <equal>net.sf.cord</equal>
     <equal>com.thinomenon.RemoteDesktopConnection</equal>
     <equal>com.itap-mobile.qmote</equal>
+    <equal>com.nulana.remotixmac</equal>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
This PR adds [Remotix](http://www.nulana.com/remotix-mac/) to the `REMOTEDESKTOPCONNECTION` definition.
