### PR TITLE
Added polish.xml with swap command_r with options_r

### DIFF
--- a/src/core/server/Resources/checkbox.xml
+++ b/src/core/server/Resources/checkbox.xml
@@ -121,6 +121,7 @@
   <include path="include/checkbox/languages/korean.xml" />
   <include path="include/checkbox/languages/lithuanian.xml" />
   <include path="include/checkbox/languages/norwegian.xml" />
+  <include path="include/checkbox/languages/polish.xml" />
   <include path="include/checkbox/languages/portuguese.xml" />
   <include path="include/checkbox/languages/russian.xml" />
   <include path="include/checkbox/languages/slovenian.xml" />

--- a/src/core/server/Resources/include/checkbox/languages/polish.xml
+++ b/src/core/server/Resources/include/checkbox/languages/polish.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>For Polish</name>
+    <item>
+      <name>Swap Command_R with Options_R</name>
+      <identifier>remap.polish_keypad_swap_command_r_with_options_r</identifier>
+      <autogen>__KeyToKey__ KeyCode::COMMAND_R, KeyCode::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::OPTION_R, KeyCode::COMMAND_R</autogen>
+    </item>
+  </item>
+</root>


### PR DESCRIPTION
In Poland it is very common to alter the default keyboard mapping in MacOS by swapping the right command key with the right options key. [Popular polish blog post](http://www.makoweabc.pl/2013/07/polskie-znaki-w-os-x-za-pomoca-prawego-%E2%8C%98-zamiast-%E2%8C%A5/) that describes the Karabiner setup, attaching the changes that automate this setup.
