### PR TITLE
Added Middle to Back (+ Middle+CursorMove to ScrollWheel)

### DIFF
--- a/src/core/server/Resources/include/checkbox/pointing_device.xml
+++ b/src/core/server/Resources/include/checkbox/pointing_device.xml
@@ -216,6 +216,18 @@
         </autogen>
       </item>
       <item>
+        <name>Middle to Back (command-[)</name>
+        <appendix>(+ Middle+CursorMove to ScrollWheel)</appendix>
+        <identifier>remap.pointing_middle_to_back_scrollwheel</identifier>
+        <autogen>
+          __PointingRelativeToScroll__
+          PointingButton::MIDDLE,
+
+          Option::POINTINGRELATIVETOSCROLL_TOKEYS,
+          KeyCode::BRACKET_LEFT, ModifierFlag::COMMAND_L,
+        </autogen>
+      </item>
+      <item>
         <name>(Simultaneous) LeftClick+RightClick to MiddleClick</name>
         <identifier>remap.pointing_leftrightclick2middleclick</identifier>
         <autogen>__SimultaneousKeyPresses__ PointingButton::LEFT, PointingButton::RIGHT, PointingButton::MIDDLE</autogen>


### PR DESCRIPTION
Added mapping for Middle to Back (+ Middle+CursorMove to ScrollWheel). 

I've been using this with the Logitech Marble Mouse to keep the back button functionality while still using back + cursor for scrolling. 