### PR TITLE
add Emacs bindings for Word

### DIFF
--- a/src/core/server/Resources/include/checkbox/apps/office.xml
+++ b/src/core/server/Resources/include/checkbox/apps/office.xml
@@ -103,4 +103,16 @@
       <autogen>__KeyToKey__ FROMKEYCODE_PAGEDOWN, KeyCode::CURSOR_DOWN, ModifierFlag::OPTION_L</autogen>
     </item>
   </item>
+  <item>
+    <name>Enable at only Word</name>
+    <item>
+      <name>Emacs bindings for Word</name>
+      <identifier>remap.app_word_emacs_bindings</identifier>
+      <only>WORD</only>
+      <autogen>__KeyToKey__ KeyCode::E, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL, KeyCode::END</autogen>
+      <autogen>__KeyToKey__ KeyCode::A, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL, KeyCode::HOME</autogen>
+      <autogen>__KeyToKey__ KeyCode::H, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL, KeyCode::DELETE</autogen>
+      <autogen>__KeyToKey__ KeyCode::D, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL, KeyCode::FORWARD_DELETE</autogen>
+    </item>
+  </item>
 </root>


### PR DESCRIPTION
Some bindings in Word are different from Emacs.
This patch corrects them.