### PR TITLE
Add non-breaking return to normal return mapping

### DIFF
--- a/src/core/server/Resources/include/checkbox/standards/return.xml
+++ b/src/core/server/Resources/include/checkbox/standards/return.xml
@@ -73,11 +73,9 @@
       <autogen>__KeyToKey__ KeyCode::RETURN, KeyCode::VK_NONE</autogen>
     </item>
     <item>
-      <name>Non-Breaking Return to Normal Return</name>
-      <appendix>(Option+Return to Return)</appendix>
+      <name>Linefeed to Return</name>
       <appendix>(Control+Return to Return)</appendix>
       <identifier>remap.option_return_to_return</identifier>
-      <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::RETURN</autogen>
       <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL | ModifierFlag::NONE, KeyCode::RETURN</autogen>
     </item>
   </item>

--- a/src/core/server/Resources/include/checkbox/standards/return.xml
+++ b/src/core/server/Resources/include/checkbox/standards/return.xml
@@ -72,5 +72,13 @@
       <identifier>remap.drop_return</identifier>
       <autogen>__KeyToKey__ KeyCode::RETURN, KeyCode::VK_NONE</autogen>
     </item>
+    <item>
+      <name>Non-Breaking Return to Normal Return</name>
+      <appendix>(Option+Return to Return)</appendix>
+      <appendix>(Option+Shift+Return to Return)</appendix>
+      <identifier>remap.option_return_to_return</identifier>
+      <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::RETURN</autogen>
+      <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::RETURN</autogen>
+    </item>
   </item>
 </root>

--- a/src/core/server/Resources/include/checkbox/standards/return.xml
+++ b/src/core/server/Resources/include/checkbox/standards/return.xml
@@ -75,10 +75,10 @@
     <item>
       <name>Non-Breaking Return to Normal Return</name>
       <appendix>(Option+Return to Return)</appendix>
-      <appendix>(Option+Shift+Return to Return)</appendix>
+      <appendix>(Control+Return to Return)</appendix>
       <identifier>remap.option_return_to_return</identifier>
       <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::RETURN</autogen>
-      <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::RETURN</autogen>
+      <autogen>__KeyToKey__ KeyCode::RETURN, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL | ModifierFlag::NONE, KeyCode::RETURN</autogen>
     </item>
   </item>
 </root>


### PR DESCRIPTION
This prevents accidental presses of option-return, instead substituting them with a plain return.

Very similar to the mapping at: https://github.com/tekezo/Karabiner/blob/master/src/core/server/Resources/include/checkbox/standards/space.xml#L146