### PR TITLE
Added APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0274

### DIFF
--- a/src/core/server/Resources/deviceproductdef.xml
+++ b/src/core/server/Resources/deviceproductdef.xml
@@ -57,6 +57,11 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0274</productname>
+    <productid>0x0274</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>APPLE_EXTERNAL_KEYBOARD_0x0203</productname>
     <productid>0x0203</productid>
   </deviceproductdef>


### PR DESCRIPTION
...as found on my shiny new Retina MacBook Pro (mid-2015). I can't seem to be able to specify a raw number in the `private.xml` (i.e. test with 0x274) so this is yet untested code.

If you like me to verify it before we merge, please suggest what file I can hack this into in my Karabiner install. The device ID is what is shown in Karabiner's Event Viewer.

(btw, thanks again for an extremely nice app. :smile:)