### PR TITLE
Add magic keyboard and magic trackpad 0x0265

### DIFF
--- a/Tests/lib/xml_compiler/data/system_xml/deviceproductdef.xml
+++ b/Tests/lib/xml_compiler/data/system_xml/deviceproductdef.xml
@@ -83,6 +83,16 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>MAGIC_TRACKPAD</productname>
+    <productid>0x030e</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
+    <productname>MAGIC_TRACKPAD_0x0265</productname>
+    <productid>0x0265</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>TYPEMATRIX_KEYBOARD_0x2030</productname>
     <productid>0x2030</productid>
   </deviceproductdef>

--- a/Tests/lib/xml_compiler/data/system_xml/deviceproductdef.xml
+++ b/Tests/lib/xml_compiler/data/system_xml/deviceproductdef.xml
@@ -73,6 +73,11 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>MAGIC_KEYBOARD</productname>
+    <productid>0x0267</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>MAGIC_MOUSE</productname>
     <productid>0x030d</productid>
   </deviceproductdef>

--- a/src/core/server/Resources/deviceproductdef.xml
+++ b/src/core/server/Resources/deviceproductdef.xml
@@ -117,6 +117,11 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>MAGIC_KEYBOARD</productname>
+    <productid>0x0267</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>APPLE_WIRELESS_TRACKPAD_0x030e</productname>
     <productid>0x030e</productid>
   </deviceproductdef>

--- a/src/core/server/Resources/deviceproductdef.xml
+++ b/src/core/server/Resources/deviceproductdef.xml
@@ -137,6 +137,11 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>MAGIC_TRACKPAD_0x0265</productname>
+    <productid>0x0265</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>TYPEMATRIX_KEYBOARD_0x2030</productname>
     <productid>0x2030</productid>
   </deviceproductdef>

--- a/src/core/server/Resources/include/checkbox/device_specific.xml
+++ b/src/core/server/Resources/include/checkbox/device_specific.xml
@@ -157,7 +157,7 @@
         <appendix>(This setting flips only pointer and scroll. So, gestures do not work properly.</appendix>
         <appendix>Please disable gestures from System Preferences.)</appendix>
         <identifier>remap.flip_magic_trackpad</identifier>
-        <device_only>DeviceVendor::APPLE_INC, DeviceProduct::MAGIC_TRACKPAD</device_only>
+        <device_only>DeviceVendor::APPLE_INC, DeviceProduct::MAGIC_TRACKPAD, DeviceProduct::MAGIC_TRACKPAD_0x0265</device_only>
         <autogen>
           __FlipPointingRelative__
           Option::FLIPPOINTINGRELATIVE_HORIZONTAL,

--- a/src/core/server/Resources/include/checkbox/device_specific.xml
+++ b/src/core/server/Resources/include/checkbox/device_specific.xml
@@ -143,7 +143,7 @@
         <name>Disable ScrollWheel</name>
         <identifier>remap.dropscrollwheel_0x05ac_0x030d</identifier>
         <block>
-          <device_only>DeviceVendor::APPLE_COMPUTER,DeviceProduct::MAGIC_MOUSE</device_only>
+          <device_only>DeviceVendor::APPLE_COMPUTER,DeviceProduct::MAGIC_KEYBOARD,DeviceProduct::MAGIC_MOUSE</device_only>
           <autogen>__DropScrollWheel__</autogen>
         </block>
       </item>


### PR DESCRIPTION
`system_profiler SPBluetoothDataType` results for these devices are following:

```console
$ system_profiler SPBluetoothDataType
Bluetooth:
...
     Devices (Paired, Configured, etc.):
          Magic Trackpad 2:
              Major Type: Peripheral
              Minor Type: Trackpad
              Services: Magic Trackpad 2
              Manufacturer: Broadcom (0x5, 0x240C)
              Firmware Version: 0x0062
              Vendor ID: 0x004C
              Product ID: 0x0265
              Host Connectable: Yes
              EDR Supported: Yes
              eSCO Supported: No
              SSP Supported: Yes
...
          Magic Keyboard:
              Major Type: Peripheral
              Minor Type: Keyboard
              Services: Magic Keyboard
              Manufacturer: Broadcom (0x5, 0x240C)
              Firmware Version: 0x0063
              Vendor ID: 0x004C
              Product ID: 0x0267
              Host Connectable: Yes
              EDR Supported: Yes
              eSCO Supported: No
              SSP Supported: Yes
...
```

I don't have Magic Mouse 2 and don't know its product id.