### PR TITLE
Added additional Ctrl-X settings for vim_emu

### DIFF
--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core.xml
@@ -26,6 +26,7 @@
   <include path="vim_emu_core_disable.xml"></include>
   <include path="vim_emu_core_lb.xml"></include>
   <include path="vim_emu_core_reset.xml"></include>
+  <include path="vim_emu_core_insert.xml"></include>
   <!--
   <include path="vim_emu_core_vb.xml"></include>
   <include path="vim_emu_core_rep.xml"></include>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_insert.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_insert.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>Additional settings of Control + X at insert mode</name>
+    <identifier>remap.vim_emu_ctl_x_at_insert{{VIM_EMU_ALTCONFIG}}</identifier>
+    <only>{{VIM_EMU_ONLY_APPS}}</only>
+    <not>{{VIM_EMU_IGNORE_APPS}}</not>
+    <block>
+      <block> <!-- Complement Mode -->
+        <config_only>notsave.vim_emu_complement{{VIM_EMU_ALTCONFIG}}</config_only>
+        <autogen>
+          __HoldingKeyToKey__ KeyCode::C,
+          KeyCode::RETURN,
+          KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_NONE,
+          KeyCode::ESCAPE, Option::NOREPEAT
+        </autogen>
+      </block>
+      <block> <!-- Search Mode -->
+        <config_only>notsave.vim_emu_search{{VIM_EMU_ALTCONFIG}}</config_only>
+        <autogen>
+          __HoldingKeyToKey__ KeyCode::C,
+          KeyCode::ESCAPE,
+          KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_search{{VIM_EMU_ALTCONFIG}},
+          {{VIM_EMU_EMU_ON}}
+          KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_NONE,
+          KeyCode::ESCAPE, Option::NOREPEAT
+        </autogen>
+      </block>
+      <block> <!-- Turn Off also IME if enabled -->
+        <inputsource_only>JAPANESE</inputsource_only>
+        <autogen>
+          __HoldingKeyToKey__ KeyCode::C,
+          KeyCode::VK_CHANGE_INPUTSOURCE_ENGLISH,
+          KeyCode::VK_CHANGE_INPUTSOURCE_JAPANESE,
+          KeyCode::VK_CHANGE_INPUTSOURCE_ENGLISH,
+          {{VIM_EMU_FORCE_ON_NORMAL_MODE}},
+          KeyCode::VK_NONE,
+          KeyCode::ESCAPE, Option::NOREPEAT
+        </autogen>
+      </block>
+      <!-- Others -->
+      <config_not>notsave.vim_emu_normal{{VIM_EMU_ALTCONFIG}}</config_not>
+      <autogen>
+        __HoldingKeyToKey__ KeyCode::C,
+        {{VIM_EMU_FORCE_ON_NORMAL_MODE}},
+        KeyCode::VK_NONE,
+        KeyCode::ESCAPE, Option::NOREPEAT
+      </autogen>
+    </block>
+    <autogen>
+      __KeyToKey__ KeyCode::I,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::TAB
+    </autogen>
+    <autogen>
+      __KeyToKey__ KeyCode::J,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::RETURN
+    </autogen>
+    <autogen>
+      __KeyToKey__ KeyCode::M,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::RETURN
+    </autogen>
+    <autogen>
+      __KeyToKey__ KeyCode::T,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::CURSOR_LEFT, VK_COMMAND,
+      KeyCode::TAB
+    </autogen>
+    <autogen>
+      __KeyToKey__ KeyCode::U,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::CURSOR_LEFT, VK_COMMAND, VK_SHIFT,
+      KeyCode::X, VK_COMMAND
+    </autogen>
+    <autogen>
+      __KeyToKey__ KeyCode::W,
+      VK_CONTROL|ModifierFlag::NONE,
+      KeyCode::CURSOR_LEFT, VK_OPTION, VK_SHIFT,
+      KeyCode::X, VK_COMMAND
+    </autogen>
+  </item>
+</root>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
@@ -123,6 +123,15 @@
         <appendix>Ctrl-n/p: Enter Complement mode:</appendix>
         <appendix>* In Complement mode, use Ctrl-n/p to choose a candidate.</appendix>
         <appendix>* Ctrl-h to skip, ESC/Ctrl-[ to choose a candidate.</appendix>
+        <appendix>With **Additional settings of Control + X at insert mode.**</appendix>
+        <appendix>* Ctrl-c: Change to normal mode.</appendix>
+        <appendix>* Ctrl-i: Tab.</appendix>
+        <appendix>* Ctrl-j: Return.</appendix>
+        <appendix>* Ctrl-m: Return.</appendix>
+        <appendix>* Ctrl-t: Insert Tab at the beggining of current line.</appendix>
+        <appendix>* Ctrl-u: Cut the text between the beggining of the line and the current position.</appendix>
+        <appendix>* Ctrl-w: Cut the word before the cursor.</appendix>
+        <appendix>* Note: Some Control-X shortcut keys emacs like movements are originally available in Mac (see https://support.apple.com/en-ap/HT201236).</appendix>
       </item>
     </item>
     <item>


### PR DESCRIPTION
New option **Additional settings of Control + X at insert mode** was added.
It enables following keys at "Insert Mode" of vim_emu:

|Key/Commands|Function|
|:----------:|:-------|
|Ctrl-c| Enter Normal mode.|
|Ctrl-i| Insert Tab.|
|Ctrl-j| Return.|
|Ctrl-m| Return.|
|Ctrl-t| Insert tab at the beginning of current line.|
|Ctrl-u| Cut the text between the beginning of the line and the current position.|
|Ctrl-w| Cut the word before the cursor.|