### PR TITLE
Add Control+_ as undo for Emacs Mode

### DIFF
--- a/src/core/server/Resources/include/checkbox/emacs_mode.xml
+++ b/src/core/server/Resources/include/checkbox/emacs_mode.xml
@@ -368,7 +368,7 @@
       </autogen>
     </item>
     <item>
-      <name>Control+/ to Command_Z</name>
+      <name>Control+/ to Command+Z</name>
       <identifier>option.emacsmode_controlSlash</identifier>
       <not>{{EMACS_MODE_IGNORE_APPS}}</not>
       <modifier_not>
@@ -378,6 +378,20 @@
       <autogen>
         __KeyToKey__
         KeyCode::SLASH, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL,
+        KeyCode::Z, ModifierFlag::COMMAND_L,
+      </autogen>
+    </item>
+    <item>
+      <name>Control+_ to Command+Z</name>
+      <identifier>option.emacsmode_controlUnderscore</identifier>
+      <not>{{EMACS_MODE_IGNORE_APPS}}</not>
+      <modifier_not>
+        ModifierFlag::COMMAND_L, ModifierFlag::COMMAND_R,
+        ModifierFlag::OPTION_L,  ModifierFlag::OPTION_R,
+      </modifier_not>
+      <autogen>
+        __KeyToKey__
+        KeyCode::MINUS, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT,
         KeyCode::Z, ModifierFlag::COMMAND_L,
       </autogen>
     </item>


### PR DESCRIPTION
Control+_ is one of the three standard Emacs undo key combos (see
http://www.gnu.org/software/emacs/manual/html_node/emacs/Undo.html), but
was not previously included in the default Karabiner key definitions.
This adds it.

Also changes the name of the Control+/ undo command to be more
consistent with naming for other options.