### PR TITLE
adding more buttons as potential modifiers for fancy combinations

### DIFF
--- a/src/core/server/Resources/modifierdef.xml
+++ b/src/core/server/Resources/modifierdef.xml
@@ -111,5 +111,19 @@
   <modifierdef notify="false">BUTTON3</modifierdef>
   <modifierdef notify="false">BUTTON4</modifierdef>
   <modifierdef notify="false">BUTTON5</modifierdef>
+  <modifierdef notify="false">BUTTON6</modifierdef>
+  <modifierdef notify="false">BUTTON7</modifierdef>
+  <modifierdef notify="false">BUTTON8</modifierdef>
+  <modifierdef notify="false">BUTTON9</modifierdef>
+  <modifierdef notify="false">BUTTON10</modifierdef>
+  <modifierdef notify="false">BUTTON11</modifierdef>
+  <modifierdef notify="false">BUTTON12</modifierdef>
+  <modifierdef notify="false">BUTTON13</modifierdef>
+  <modifierdef notify="false">BUTTON14</modifierdef>
+  <modifierdef notify="false">BUTTON15</modifierdef>
+  <modifierdef notify="false">BUTTON16</modifierdef>
+  <modifierdef notify="false">BUTTON17</modifierdef>
+  <modifierdef notify="false">BUTTON18</modifierdef>
+  <modifierdef notify="false">BUTTON19</modifierdef>
 
 </root>


### PR DESCRIPTION
Following up on https://groups.google.com/forum/?#!msg/osx-karabiner/xo111A0jqPQ/vNsK33SiGQAJ

I had a typo in that post. I meant button6. Well, turns out only mouse buttons up through 5 have modifierdefs. Adding <modifierdef>BUTTON6</modifierdef> in my private.xml made the thing work, but I figure it'd be nice to have more buttons available for use as modifiers.

OS X version: OS X 10.11.3
Karabiner version: Karabiner 10.15.39
Your Mac hardware: MacBook Air
Your keyboard hardware: Das Keyboard S Ultimate
Your mouse hardware: Logitech M705