### PR TITLE
Separated complement at insert mode for Vim Emulation

### DIFF
--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core.xml
@@ -22,6 +22,7 @@
   </item>
   <include path="vim_emu_core_ck.xml"></include>
   <include path="vim_emu_core_emu.xml"></include>
+  <include path="vim_emu_core_complement.xml"></include>
   <include path="vim_emu_core_rm.xml"></include>
   <include path="vim_emu_core_disable.xml"></include>
   <include path="vim_emu_core_lb.xml"></include>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_complement.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_complement.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>Enable Vim like complement</name>
+    <identifier>remap.vim_emu_complement_{{VIM_EMU_ALTCONFIG}}</identifier>
+    <only>{{VIM_EMU_ONLY_APPS}}</only>
+    <not>{{VIM_EMU_IGNORE_APPS}}</not>
+    <block> <!-- Insert Mode (OS Normal State) Begin -->
+      <!-- Insert Mode: Complement Begin -->
+      <config_not>notsave.vim_emu{{VIM_EMU_ALTCONFIG}}</config_not>
+      <autogen>
+        __KeyToKey__ KeyCode::N,
+        VK_CONTROL|ModifierFlag::NONE,
+        KeyCode::ESCAPE,
+        {{VIM_EMU_EMU_ON}}
+        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+      <autogen>
+        __KeyToKey__ KeyCode::P,
+        VK_CONTROL|ModifierFlag::NONE,
+        KeyCode::ESCAPE,
+          {{VIM_EMU_EMU_ON}}
+        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+      <!-- Insert Mode: Complement End -->
+    </block> <!-- Insert Mode End -->
+
+    <block> <!-- Complement Mode Begin -->
+      <config_only>notsave.vim_emu_complement{{VIM_EMU_ALTCONFIG}}</config_only>
+      <autogen>
+        __KeyToKey__ KeyCode::N,
+        VK_CONTROL|ModifierFlag::NONE,
+        KeyCode::CURSOR_DOWN,
+      </autogen>
+      <autogen>
+        __KeyToKey__ KeyCode::P,
+        VK_CONTROL|ModifierFlag::NONE,
+        KeyCode::CURSOR_UP,
+      </autogen>
+      <autogen>
+        __KeyToKey__ KeyCode::H,
+        VK_CONTROL|ModifierFlag::NONE,
+        KeyCode::ESCAPE,
+        {{VIM_EMU_EMU_ON}}
+        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+      <autogen>
+        __KeyToKey__ KeyCode::RETURN, ModifierFlag::NONE,
+        KeyCode::RETURN,
+        {{VIM_EMU_EMU_OFF}}
+        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+      </autogen>
+    </block> <!-- Complement Mode End -->
+  </item>
+</root>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
@@ -6,53 +6,6 @@
     <only>{{VIM_EMU_ONLY_APPS}}</only>
     <not>{{VIM_EMU_IGNORE_APPS}}</not>
 
-    <block> <!-- Insert Mode (OS Normal State) Begin -->
-      <!-- Insert Mode: Complement Begin -->
-      <config_not>notsave.vim_emu{{VIM_EMU_ALTCONFIG}}</config_not>
-      <autogen>
-        __KeyToKey__ KeyCode::N,
-        VK_CONTROL|ModifierFlag::NONE,
-        KeyCode::ESCAPE,
-        {{VIM_EMU_EMU_ON}}
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-      <autogen>
-        __KeyToKey__ KeyCode::P,
-        VK_CONTROL|ModifierFlag::NONE,
-        KeyCode::ESCAPE,
-          {{VIM_EMU_EMU_ON}}
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-      <!-- Insert Mode: Complement End -->
-    </block> <!-- Insert Mode End -->
-
-    <block> <!-- Complement Mode Begin -->
-      <config_only>notsave.vim_emu_complement{{VIM_EMU_ALTCONFIG}}</config_only>
-      <autogen>
-        __KeyToKey__ KeyCode::N,
-        VK_CONTROL|ModifierFlag::NONE,
-        KeyCode::CURSOR_DOWN,
-      </autogen>
-      <autogen>
-        __KeyToKey__ KeyCode::P,
-        VK_CONTROL|ModifierFlag::NONE,
-        KeyCode::CURSOR_UP,
-      </autogen>
-      <autogen>
-        __KeyToKey__ KeyCode::H,
-        VK_CONTROL|ModifierFlag::NONE,
-        KeyCode::ESCAPE,
-        {{VIM_EMU_EMU_ON}}
-        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-      <autogen>
-        __KeyToKey__ KeyCode::RETURN, ModifierFlag::NONE,
-        KeyCode::RETURN,
-        {{VIM_EMU_EMU_OFF}}
-        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-    </block> <!-- Complement Mode End -->
-
     <!-- Enter G Mode Begin -->
     <block>
       <config_only>notsave.vim_emu{{VIM_EMU_ALTCONFIG}}</config_only>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
@@ -120,7 +120,7 @@
         <name></name>
         <appendix>Starting from this mode</appendix>
         <appendix>ESC/Ctrl-[ (or other ChangeKeys): Enter VIM Normal mode</appendix>
-        <appendix>Ctrl-n/p: Enter Complement mode:</appendix>
+        <appendix>Ctrl-n/p: Enter Complement mode, if "Enable Vim like complement" is checked:</appendix>
         <appendix>* In Complement mode, use Ctrl-n/p to choose a candidate.</appendix>
         <appendix>* Ctrl-h to skip, ESC/Ctrl-[ to choose a candidate.</appendix>
         <appendix>With **Additional settings of Control + X at insert mode.**</appendix>


### PR DESCRIPTION
Update for Vim Emulation.
Additional option was added to enable/disable a complement at the insert mode.
The default setting is now that the complement mode is disabled.