### PR TITLE
Add support for Logitech M505

### DIFF
--- a/src/core/server/Resources/include/checkbox/devices/logitech_m505.xml
+++ b/src/core/server/Resources/include/checkbox/devices/logitech_m505.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
+<!-- Adds workspace and mission control support for Logitech M505 Mouse -->
 <root>
     <item>
         <name>Logitech M505 mouse</name>
-        <appendix>Adds Support for Scroll Button (Move a Workspace Left or Right & Show workspace on Scroll Click)</appendix>
+        <appendix>Adds Support for Scroll Button (Move a Workspace Left or Right and Show workspace on Scroll Click)</appendix>
 
         <!-- First setup the keyboard shortcut on your mac "Keyboard > Shortcuts > Enable "Move Left a Space" / "Move Right a Space" " -->
         <!-- Do the same for Workspace (3rd item) - Show workspace on middle click -->
@@ -16,7 +17,7 @@
         <!-- Which will move left a space -->
         <item>
             <name>Move Left a Workspace (on M505 Scroll Wheel Tilt Left)</name>
-            <identifier>logitech.m505.scroll.left</identifier>
+            <identifier>device.logitech.m505.scroll.workspace.left</identifier>
             <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
             <autogen>
                 __ScrollWheelToKey__ ScrollWheel::LEFT,
@@ -27,7 +28,7 @@
         <!-- Same as above but moving RIGHT a workspace -->
         <item>
             <name>Move Right a Workspace (on M505 Scroll Wheel Tilt Right)</name>
-            <identifier>logitech.m505.scroll.right</identifier>
+            <identifier>device.logitech.m505.scroll.workspace.right</identifier>
             <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
             <autogen>
                 __ScrollWheelToKey__
@@ -39,7 +40,7 @@
         <!-- Show workspace on click of the middle button (wheel click) -->
         <item>
             <name>Show Mission Control (on M505 Wheel Click)</name>
-            <identifier>logitech.m505.wheel.click</identifier>
+            <identifier>device.logitech.m505.wheel.click.mission.control</identifier>
             <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
             <autogen>
                 __KeyToKey__ PointingButton::MIDDLE,

--- a/src/core/server/Resources/include/checkbox/devices/logitech_m505.xml
+++ b/src/core/server/Resources/include/checkbox/devices/logitech_m505.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<root>
+    <item>
+        <name>Logitech M505 mouse</name>
+        <appendix>Adds Support for Scroll Button (Move a Workspace Left or Right & Show workspace on Scroll Click)</appendix>
+
+        <!-- First setup the keyboard shortcut on your mac "Keyboard > Shortcuts > Enable "Move Left a Space" / "Move Right a Space" " -->
+        <!-- Do the same for Workspace (3rd item) - Show workspace on middle click -->
+        <!-- Now we remap the mouse keys to that shortcut (by default was Control + Left/Right) -->
+
+        <!-- How does this work? -->
+        <!-- Basically, We add our name, identifier, device_only  -->
+        <!-- then our autogen, the first line is what we're mapping from (__ScrollWheelToKey__ or __KeyToKey__)  -->
+        <!-- The Second line is what we want to map to (in this case our workspace shortcuts) -->
+        <!-- So the below example maps the "__ScrollWheelToKey__ ScrollWheel::LEFT" to "KeyCode::CURSOR_LEFT, ModifierFlag::CONTROL_L" -->
+        <!-- Which will move left a space -->
+        <item>
+            <name>Move Left a Workspace (on M505 Scroll Wheel Tilt Left)</name>
+            <identifier>logitech.m505.scroll.left</identifier>
+            <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
+            <autogen>
+                __ScrollWheelToKey__ ScrollWheel::LEFT,
+                KeyCode::CURSOR_LEFT, ModifierFlag::CONTROL_L
+            </autogen>
+        </item>
+
+        <!-- Same as above but moving RIGHT a workspace -->
+        <item>
+            <name>Move Right a Workspace (on M505 Scroll Wheel Tilt Right)</name>
+            <identifier>logitech.m505.scroll.right</identifier>
+            <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
+            <autogen>
+                __ScrollWheelToKey__
+                ScrollWheel::RIGHT,
+                KeyCode::CURSOR_RIGHT, ModifierFlag::CONTROL_L
+            </autogen>
+        </item>
+
+        <!-- Show workspace on click of the middle button (wheel click) -->
+        <item>
+            <name>Show Mission Control (on M505 Wheel Click)</name>
+            <identifier>logitech.m505.wheel.click</identifier>
+            <device_only>DeviceVendor::LOGITECH, DeviceProduct::LOGITECH_USB_RECEIVER</device_only>
+            <autogen>
+                __KeyToKey__ PointingButton::MIDDLE,
+                KeyCode::CURSOR_UP, ModifierFlag::CONTROL_L | ModifierFlag::SHIFT_L
+            </autogen>
+        </item>
+    </item>
+</root>


### PR DESCRIPTION
**Features**

1. Added support for Logitech Moving Workspace with the wheel button and show workspace.

---

I have a Logitech M505 Mouse.
http://www.amazon.co.uk/Logitech-M505-Wireless-Mouse-Silver/dp/B002L3TSKW

Karabiner is a great BetterTouchTool alternative, I managed to replicate all my needs with Karabiner. Now I can get rid of BetterTouchTool. 

Hope this helps someone! - It's quite a popular mouse, friends also have the same model.

:smiley: 