### PR TITLE
tweak chrome remote desktop regex

### DIFF
--- a/src/core/server/Resources/windownamedef.xml
+++ b/src/core/server/Resources/windownamedef.xml
@@ -7,7 +7,7 @@
 
   <windownamedef>
     <name>Chrome_Remote_Desktop</name>
-    <regex>^Chrome Remote Desktop$</regex>
+    <regex>Chrome Remote Desktop</regex>
   </windownamedef>
 
   <windownamedef>


### PR DESCRIPTION
my chrome remote desktop window titles include the name of the remote machine e.g. "HFC-WebRF - Chrome Remote Desktop"
i propose removing at least the ^ as well as $ while we're at it since that should still have plenty of specificity
confirmed working for me via private.xml override