### PR TITLE
Don't disable internal keyboard when MS designer mouse is connected.

### DIFF
--- a/src/bridge/generator/keycode/data/DeviceProduct.data
+++ b/src/bridge/generator/keycode/data/DeviceProduct.data
@@ -17,6 +17,7 @@ Mionix_Naos_7000                        0x130c
 
 // Microsoft
 Microsoft_Sculpt_Touch_Mouse            0x077c
+Microsoft_Designer_Bluetooth_Mouse      0x0805
 
 //
 PSEUDO                                  0x0000

--- a/src/core/kext/Classes/ListHookedKeyboard.cpp
+++ b/src/core/kext/Classes/ListHookedKeyboard.cpp
@@ -340,10 +340,12 @@ bool ListHookedKeyboard::isExternalDevicesConnected(void) const {
     // * Mionix Naos 7000
     // * Logitech Bluetooth Mouse M555b
     // * Microsoft Sculpt Touch Mouse
+    // * Microsoft Designer Bluetooth Mouse
     if (p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor::Razer, DeviceProduct::Razer_DeathAdder_Chroma) ||
         p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor::Mionix, DeviceProduct::Mionix_Naos_7000) ||
         p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor::LOGITECH, DeviceProduct::Logitech_Bluetooth_Mouse_M555b) ||
         p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor::MICROSOFT, DeviceProduct::Microsoft_Sculpt_Touch_Mouse) ||
+        p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor::MICROSOFT, DeviceProduct::Microsoft_Designer_Bluetooth_Mouse) ||
 #if 0
         /* Debug code: HHKB Professional JP */
         p->getDeviceIdentifier().isEqualVendorProduct(DeviceVendor(0x04fe), DeviceProduct(0x000d)) ||


### PR DESCRIPTION
Issue: 

When connect MS designer mouse to Mac, internal keyboard get disabled if "disable internal keyboard while external keyboards are connected" is enabled.

Cause:
MS designer mouse appears as consumer in the event viewer

```
Keyboard
    Apple Internal Keyboard / Trackpad (Apple Inc.)

    DeviceVendor::RawValue::0x05ac,
    DeviceProduct::RawValue::0x0262,

    DeviceLocation::RawValue::0x14400000,

Consumer
    Apple Internal Keyboard / Trackpad (Apple Inc.)

    DeviceVendor::RawValue::0x05ac,
    DeviceProduct::RawValue::0x0262,

    DeviceLocation::RawValue::0x14400000,

Consumer
    Designer Mouse ()

    DeviceVendor::RawValue::0x045e,
    DeviceProduct::RawValue::0x0805,

    DeviceLocation::RawValue::0x3ad39414,

Pointing
    Apple Internal Keyboard / Trackpad (Apple Inc.)

    DeviceVendor::RawValue::0x05ac,
    DeviceProduct::RawValue::0x0262,

    DeviceLocation::RawValue::0x14400000,

Pointing
    Designer Mouse ()

    DeviceVendor::RawValue::0x045e,
    DeviceProduct::RawValue::0x0805,

    DeviceLocation::RawValue::0x3ad39414,
```

Fix:

Add the designer mouse to the ignore list