### PR TITLE
adding vendor device IDs for powerbood trackpad and logitech M305

### DIFF
--- a/src/core/server/Resources/deviceproductdef.xml
+++ b/src/core/server/Resources/deviceproductdef.xml
@@ -57,6 +57,11 @@
   </deviceproductdef>
 
   <deviceproductdef>
+    <productname>APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0273</productname>
+    <productid>0x0273</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
     <productname>APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0274</productname>
     <productid>0x0274</productid>
   </deviceproductdef>
@@ -194,6 +199,11 @@
   <deviceproductdef>
     <productname>LOGITECH_R400</productname>
     <productid>0xc52d</productid>
+  </deviceproductdef>
+
+  <deviceproductdef>
+    <productname>LOGITECH_M305</productname>
+    <productid>0xc52f</productid>
   </deviceproductdef>
 
   <deviceproductdef>


### PR DESCRIPTION
I found the trackpad ID for my macbook was not in the product def list. Additionally, I did not find the vendor product ID for my Logitech M305 mouse. I have added both. Attached is a screen shot of the event viewer showing the product IDs.

Macbook details: "Model Identifier: MacBookPro12,1", retina 13", early 2015

<img width="866" alt="eventviewer" src="https://cloud.githubusercontent.com/assets/361454/15658547/9fb7a0b4-2672-11e6-9882-2c6038ecf911.png">
