### PR TITLE
Updated VIM Emulation

### DIFF
--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_emu.xml
@@ -133,15 +133,29 @@
         KeyCode::VK_LOCK_EXTRA2_FORCE_OFF,
         {{VIM_EMU_NORMAL_OFF}}
       </autogen>
-      <autogen> <!-- Escape from EXTRA2 -->
-        __KeyToKey__ KeyCode::ESCAPE, ModifierFlag::EXTRA2,
-        KeyCode::VK_LOCK_EXTRA2_FORCE_OFF
-      </autogen>
-      <autogen> <!-- Escape from EXTRA2 -->
-        __KeyToKey__ KeyCode::BRACKET_LEFT, VK_CONTROL|ModifierFlag::EXTRA2,
-        KeyCode::VK_LOCK_EXTRA2_FORCE_OFF
-      </autogen>
       <!-- Normal Mode: Save, Quit End -->
+
+      <!-- Normal Mode: Zoom begin -->
+      <autogen> <!-- Zoom Mode -->
+        __KeyToKey__ KeyCode::Z, ModifierFlag::NONE,
+        KeyCode::VK_LOCK_EXTRA3_FORCE_ON
+      </autogen>
+      <autogen> <!-- Zoom In -->
+        __KeyToKey__ KeyCode::I, ModifierFlag::EXTRA3|ModifierFlag::NONE,
+        KeyCode::EQUAL, VK_SHIFT|VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA3_FORCE_OFF,
+      </autogen>
+      <autogen> <!-- Zoom Out -->
+        __KeyToKey__ KeyCode::O, ModifierFlag::EXTRA3|ModifierFlag::NONE,
+        KeyCode::MINUS, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA3_FORCE_OFF,
+      </autogen>
+      <autogen> <!-- Reset Zoom -->
+        __KeyToKey__ KeyCode::KEY_0, ModifierFlag::EXTRA3|ModifierFlag::NONE,
+        KeyCode::KEY_0, VK_COMMAND,
+        KeyCode::VK_LOCK_EXTRA3_FORCE_OFF,
+      </autogen>
+      <!-- Normal Mode: Zoom End -->
 
       <!-- Normal Mode: Search Begin -->
       <autogen>
@@ -676,18 +690,6 @@
       <autogen> <!-- Help -->
         __KeyToKey__ KeyCode::H, ModifierFlag::NONE,
         KeyCode::SLASH, VK_SHIFT|VK_COMMAND,
-        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-      <autogen> <!-- Escape from Command Mode -->
-        __KeyToKey__ KeyCode::ESCAPE, ModifierFlag::EXTRA1,
-        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
-        KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
-        KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
-      </autogen>
-      <autogen> <!-- Escape from Command Mode -->
-        __KeyToKey__ KeyCode::BRACKET_LEFT, VK_CONTROL|ModifierFlag::EXTRA1,
-        KeyCode::VK_LOCK_EXTRA1_FORCE_OFF,
         KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_command{{VIM_EMU_ALTCONFIG}},
         KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
       </autogen>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_settings.xml
@@ -160,6 +160,9 @@
           ^ : Move to the first non-blanck character of the line.
         </appendix>
         <appendix>
+          +/- : Move to the next/previous line's first character.
+        </appendix>
+        <appendix>
           w/e: Move to the next word
           (w: the beginning of the word, e: the end of the word).
         </appendix>
@@ -196,6 +199,12 @@
         <appendix>*(asterisk): Search the word under the cursor.</appendix>
         <appendix>ZZ: Save and Quit.</appendix>
         <appendix>ZQ: Quit.</appendix>
+      </item>
+      <item>
+        <name>Non text edit commands</name>
+        <appendix>zi: Zoom in.</appendix>
+        <appendix>zo: Zoom out.</appendix>
+        <appendix>z0: Zoom reset.</appendix>
       </item>
     </item>
     <item>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_move_down.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_move_down.xml
@@ -13,6 +13,22 @@
       </replacementvalue>
     </replacementdef>
   </include>
+  <!-- PLUS -->
+  <include path="vim_emu_repeat.xml">
+    <replacementdef>
+      <replacementname>VIM_EMU_REPEAT_INPUT</replacementname>
+      <replacementvalue>KeyCode::EQUAL, VK_SHIFT|ModifierFlag::NONE,</replacementvalue>
+    </replacementdef>
+    <replacementdef>
+      <replacementname>VIM_EMU_REPEAT_OUTPUT</replacementname>
+      <replacementvalue>
+        KeyCode::CURSOR_DOWN, {{VIM_EMU_USE_SHIFT}}ModifierFlag::NONE,
+        KeyCode::CURSOR_LEFT, {{VIM_EMU_USE_SHIFT}}VK_COMMAND,
+        KeyCode::CURSOR_RIGHT, {{VIM_EMU_USE_SHIFT}}VK_OPTION,
+        KeyCode::CURSOR_LEFT, {{VIM_EMU_USE_SHIFT}}VK_OPTION,
+      </replacementvalue>
+    </replacementdef>
+  </include>
   <!-- Ctrl-d -->
   <include path="vim_emu_repeat.xml">
     <replacementdef>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_move_up.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_move_up.xml
@@ -13,6 +13,22 @@
       </replacementvalue>
     </replacementdef>
   </include>
+  <!-- MINUS -->
+  <include path="vim_emu_repeat.xml">
+    <replacementdef>
+      <replacementname>VIM_EMU_REPEAT_INPUT</replacementname>
+      <replacementvalue>KeyCode::MINUS, ModifierFlag::NONE,</replacementvalue>
+    </replacementdef>
+    <replacementdef>
+      <replacementname>VIM_EMU_REPEAT_OUTPUT</replacementname>
+      <replacementvalue>
+        KeyCode::CURSOR_UP, {{VIM_EMU_USE_SHIFT}}ModifierFlag::NONE,
+        KeyCode::CURSOR_LEFT, {{VIM_EMU_USE_SHIFT}}VK_COMMAND,
+        KeyCode::CURSOR_RIGHT, {{VIM_EMU_USE_SHIFT}}VK_OPTION,
+        KeyCode::CURSOR_LEFT, {{VIM_EMU_USE_SHIFT}}VK_OPTION,
+      </replacementvalue>
+    </replacementdef>
+  </include>
   <!-- Ctrl-u -->
   <include path="vim_emu_repeat.xml">
     <replacementdef>


### PR DESCRIPTION
Added normal mode keys:

- zi/zo/z0: zoom in/out/reset
- +/-: move to the next/previous line's first character