### PR TITLE
Added customize keys to Vim Emulation

### DIFF
--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_ck.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_core_ck.xml
@@ -471,4 +471,87 @@
       </autogen>
     </block>
   </item>
+  <item>
+    <name>ChangeKey13: Customize key to enter Normal Mode</name>
+    <appendix>Set VIM_EMU_CUSTOMIZE_KEY, like (To RETURN)</appendix>
+    <appendix></appendix>
+    <appendix>&lt;replacementdef&gt;</appendix>
+    <appendix>&lt;replacementname>VIM_EMU_CUSTOMIZE_KEY&lt;/replacementname&gt;</appendix>
+    <appendix>&lt;replacementvalue>KeyCode::RETURN&lt;/replacementvalue&gt;</appendix>
+    <appendix>&lt;/replacementdef&gt;</appendix>
+    <appendix></appendix>
+    <appendix>Holding the key send original key function.</appendix>
+    <appendix>The default key is ESC (exactly same as ChangeKey1)</appendix>
+    <identifier>remap.vim_emu_customize{{VIM_EMU_ALTCONFIG}}</identifier>
+    <only>{{VIM_EMU_ONLY_APPS}}</only>
+    <not>{{VIM_EMU_IGNORE_APPS}}</not>
+    <block>
+      <block> <!-- Complement Mode -->
+        <config_only>notsave.vim_emu_complement{{VIM_EMU_ALTCONFIG}}</config_only>
+        <autogen>
+          __HoldingKeyToKey__ {{VIM_EMU_CUSTOMIZE_KEY}},
+          KeyCode::RETURN,
+          KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_complement{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_NONE,
+          {{VIM_EMU_CUSTOMIZE_KEY}}, Option::NOREPEAT
+        </autogen>
+      </block>
+      <block> <!-- Search Mode -->
+        <config_only>notsave.vim_emu_search{{VIM_EMU_ALTCONFIG}}</config_only>
+        <autogen>
+          __HoldingKeyToKey__ {{VIM_EMU_CUSTOMIZE_KEY}},
+          KeyCode::ESCAPE,
+          KeyCode::VK_CONFIG_FORCE_OFF_notsave_vim_emu_search{{VIM_EMU_ALTCONFIG}},
+          {{VIM_EMU_EMU_ON}}
+          KeyCode::VK_CONFIG_FORCE_ON_notsave_vim_emu_normal{{VIM_EMU_ALTCONFIG}},
+          KeyCode::VK_NONE,
+          {{VIM_EMU_CUSTOMIZE_KEY}}, Option::NOREPEAT
+        </autogen>
+      </block>
+      <block> <!-- Turn Off also IME if enabled -->
+        <inputsource_only>JAPANESE</inputsource_only>
+        <autogen>
+          __HoldingKeyToKey__ {{VIM_EMU_CUSTOMIZE_KEY}},
+          KeyCode::VK_CHANGE_INPUTSOURCE_ENGLISH,
+          KeyCode::VK_CHANGE_INPUTSOURCE_JAPANESE,
+          KeyCode::VK_CHANGE_INPUTSOURCE_ENGLISH,
+          {{VIM_EMU_FORCE_ON_NORMAL_MODE}},
+          KeyCode::VK_NONE,
+          {{VIM_EMU_CUSTOMIZE_KEY}}, Option::NOREPEAT
+        </autogen>
+      </block>
+      <!-- Others -->
+      <autogen>
+        __HoldingKeyToKey__ {{VIM_EMU_CUSTOMIZE_KEY}},
+        {{VIM_EMU_FORCE_ON_NORMAL_MODE}},
+        KeyCode::VK_NONE,
+        {{VIM_EMU_CUSTOMIZE_KEY}}, Option::NOREPEAT
+      </autogen>
+    </block>
+  </item>
+  <item>
+    <name>ChangeKey14: Customize simultaneous toggles Insert Mode - Normal Mode</name>
+    <appendix>Set VIM_EMU_CUSTOMIZE_SIMULTANEOUS_KEY, like</appendix>
+    <appendix></appendix>
+    <appendix>&lt;replacementdef&gt;</appendix>
+    <appendix>&lt;replacementname>VIM_EMU_CUSTOMIZE_SIMULTANEOUS_KEY&lt;/replacementname&gt;</appendix>
+    <appendix>&lt;replacementvalue>KeyCode::O, KeyCode::P&lt;/replacementvalue&gt;</appendix>
+    <appendix>&lt;/replacementdef&gt;</appendix>
+    <appendix></appendix>
+    <appendix>The default key is O and P.</appendix>
+    <identifier>remap.vim_emu_customize_toggle{{VIM_EMU_ALTCONFIG}}</identifier>
+    <only>{{VIM_EMU_ONLY_APPS}}</only>
+    <not>{{VIM_EMU_IGNORE_APPS}}</not>
+    <block>
+      <block>
+        <config_not>{{VIM_EMU_NOT_NORMAL_MODE}}</config_not>
+        <autogen>
+          __SimultaneousKeyPresses__
+          {{VIM_EMU_CUSTOMIZE_SIMULTANEOUS_KEY}},
+          {{VIM_EMU_MODE_TOGGLE}}
+        </autogen>
+      </block>
+    </block>
+  </item>
 </root>

--- a/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_replacementdef.xml
+++ b/src/core/server/Resources/include/checkbox/vim_emu/vim_emu_replacementdef.xml
@@ -138,4 +138,12 @@
     <replacementname>VIM_EMU_USE_SHIFT</replacementname>
     <replacementvalue></replacementvalue>
   </replacementdef>
+  <replacementdef>
+    <replacementname>VIM_EMU_CUSTOMIZE_KEY</replacementname>
+    <replacementvalue>KeyCode::ESCAPE</replacementvalue>
+  </replacementdef>
+  <replacementdef>
+    <replacementname>VIM_EMU_CUSTOMIZE_SIMULTANEOUS_KEY</replacementname>
+    <replacementvalue>KeyCode::O, KeyCode::P</replacementvalue>
+  </replacementdef>
 </root>


### PR DESCRIPTION
New settings for Vim Emulation, 

* ChangeKey13: Customizable key to enter normal mode.
* ChangeKey14: Customizable simultaneous key to toggle normal-insert mode.

For ChangeKey13, you can set a key as you like in your private.xml, like:

    <replacementdef>
      <replacementname>VIM_EMU_CUSTOMIZE_KEY</replacementname>
      <replacementvalue>KeyCode::RETURN</replacementvalue>
    </replacementdef>

This setting makes `RETURN` key to enter normal mode.
Under this setting, you can use `RETURN` by holding `RETURN` key.

For ChangeKey14, you can set a key to toggle Normal-Insert as you like in your private.xml, like:

    <replacementdef>
      <replacementname>VIM_EMU_CUSTOMIZE_SIMULTANEOUS_KEY</replacementname>
      <replacementvalue>KeyCode::O, KeyCode::P</replacementvalue>
    </replacementdef>