### PR TITLE
Add Keyboard not supported by Microsoft Remote Desktop

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -48,6 +48,11 @@
   </appdef>
 
   <appdef>
+    <appname>RDCMAC</appname>
+    <equal>microsoft.rdc.remotedesktop</equal>
+  </appdef>
+
+  <appdef>
     <appname>REMOTEDESKTOPCONNECTION</appname>
     <equal>com.microsoft.rdc</equal>
     <equal>com.microsoft.rdc.mac</equal>
@@ -61,6 +66,7 @@
     <equal>com.vmware.horizon</equal>
     <equal>com.2X.Client.Mac</equal>
     <equal>karabiner.remotedesktop</equal>
+    <equal>microsoft.rdc.remotedesktop</equal>
   </appdef>
 
   <appdef>

--- a/src/core/server/Resources/bundleidentifieroverridedef.xml
+++ b/src/core/server/Resources/bundleidentifieroverridedef.xml
@@ -73,20 +73,7 @@
   -->
 
   <bundleidentifieroverridedef>
-    <newbundleidentifier>karabiner.remotedesktop</newbundleidentifier>
-
-    <bundleidentifiers>
-      <equal>com.microsoft.rdc.mac</equal>
-      <equal>com.microsoft.rdc.osx.beta</equal>
-    </bundleidentifiers>
-
-    <uielementroles>
-      <equal>AXWindow</equal>
-    </uielementroles>
-  </bundleidentifieroverridedef>
-
-  <bundleidentifieroverridedef>
-    <newbundleidentifier>karabiner.remotedesktop-preferences</newbundleidentifier>
+    <newbundleidentifier>microsoft.rdc.remotedesktop-preferences</newbundleidentifier>
 
     <bundleidentifiers>
       <equal>com.microsoft.rdc.mac</equal>
@@ -105,6 +92,16 @@
     </windownames>
   </bundleidentifieroverridedef>
 
+  <bundleidentifieroverridedef>
+    <newbundleidentifier>microsoft.rdc.remotedesktop</newbundleidentifier>
+
+    <bundleidentifiers>
+      <equal>com.microsoft.rdc.mac</equal>
+      <equal>com.microsoft.rdc.osx.beta</equal>
+    </bundleidentifiers>
+
+  </bundleidentifieroverridedef>
+  
   <!-- ======================================== -->
   <!-- karabiner.remotedesktop -->
 

--- a/src/core/server/Resources/checkbox.xml
+++ b/src/core/server/Resources/checkbox.xml
@@ -96,6 +96,7 @@
     <include once="true" path="{{ ENV_Karabiner_Resources }}/include/checkbox/apps/mucommander.xml" />
     <include once="true" path="{{ ENV_Karabiner_Resources }}/include/checkbox/apps/skim.xml" />
     <include once="true" path="{{ ENV_Karabiner_Resources }}/include/checkbox/apps/twitter.xml" />
+    <include once="true" path="{{ ENV_Karabiner_Resources }}/include/checkbox/apps/microsoft_remote_desktop.xml" />
   </item>
 
   <include once="true" path="{{ ENV_Karabiner_Resources }}/include/checkbox/keyboard_layouts.xml" />

--- a/src/core/server/Resources/include/checkbox/apps/microsoft_remote_desktop.xml
+++ b/src/core/server/Resources/include/checkbox/apps/microsoft_remote_desktop.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>Enable at only Microsoft Remote Desktop for Mac</name> 
+    <item>
+      <name>Specific Language Keyboards</name>
+        <include path="microsoft_remote_desktop/A1314.xml" />
+    </item>
+  </item>
+</root>

--- a/src/core/server/Resources/include/checkbox/apps/microsoft_remote_desktop/A1314.xml
+++ b/src/core/server/Resources/include/checkbox/apps/microsoft_remote_desktop/A1314.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>French Mac keyboard A1314 using the Microsoft Remote Desktop App</name>
+    <identifier>remap.mac_A1314_keyboard_MRD_layout</identifier>
+    <only>RDCMAC</only>
+    <!-- Next keys by e-gaulue -->
+    <!-- KEY_6 to '§' -->
+    <autogen>__KeyToKey__ KeyCode::KEY_6, ModifierFlag::NONE, KeyCode::SLASH, ModifierFlag::SHIFT_R</autogen>
+    <!-- KEY_8 to '!' -->
+    <autogen>__KeyToKey__ KeyCode::KEY_8, ModifierFlag::NONE, KeyCode::SLASH, ModifierFlag::NONE</autogen>
+    <!-- FRENCH_MINUS to '-' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_MINUS, ModifierFlag::NONE, KeyCode::KEY_6, ModifierFlag::NONE</autogen>
+    <!-- FRENCH_MINUS + Shift to '_' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_MINUS, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEY_8, ModifierFlag::NONE</autogen>
+    <!-- FRENCH_@ to '@' -->
+    <autogen>__KeyToKey__ KeyCode::RawValue::0xa, ModifierFlag::NONE, KeyCode::KEY_0, ModifierFlag::OPTION_R</autogen>
+    <!-- FRENCH_@ + Shift to '#' -->
+    <autogen>__KeyToKey__ KeyCode::RawValue::0xa, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEY_3, ModifierFlag::OPTION_R</autogen>
+    <!-- FRENCH_DOLLAR + Shift to '*' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_DOLLAR, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEYPAD_MULTIPLY, ModifierFlag::NONE</autogen>
+    <!-- FRENCH_DOLLAR + AltGr to '€' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_DOLLAR, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::E, ModifierFlag::OPTION_R</autogen>
+    <!-- BACKSLASH to '`' -->
+    <autogen>__KeyToKey__ KeyCode::BACKSLASH, ModifierFlag::NONE, KeyCode::KEY_7, ModifierFlag::OPTION_R</autogen>
+    <!-- BACKSLASH + Shift to '£' -->
+    <autogen>__KeyToKey__ KeyCode::BACKSLASH, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::FRENCH_DOLLAR, ModifierFlag::SHIFT_R</autogen>
+    <!-- FRENCH_EQUAL to '=' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_EQUAL, ModifierFlag::NONE, KeyCode::EQUAL, ModifierFlag::NONE</autogen>
+    <!-- FRENCH_EQUAL + Shift to '+' -->
+    <autogen>__KeyToKey__ KeyCode::FRENCH_EQUAL, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::EQUAL, ModifierFlag::SHIFT_R</autogen>
+    <!-- Next keys by tchabaud -->
+    <!-- ALT + Shift + DOT to '\' -->
+    <autogen>__KeyToKey__ KeyCode::DOT, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEY_8, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + Shift + l to '|' -->
+    <autogen>__KeyToKey__ KeyCode::L, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEY_6, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + ( to '{' -->
+    <autogen>__KeyToKey__ KeyCode::KEY_5, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::KEY_4, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + ) to '}' -->
+    <autogen>__KeyToKey__ KeyCode::MINUS, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::MINUS, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + Shift + ( to '[' -->
+    <autogen>__KeyToKey__ KeyCode::KEY_5, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::KEY_5, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + Shift + ) to ']' -->
+    <autogen>__KeyToKey__ KeyCode::MINUS, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_SHIFT | ModifierFlag::NONE, KeyCode::MINUS, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+    <!-- ALT + n to '~' -->
+    <autogen>__KeyToKey__ KeyCode::N, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_OPTION | ModifierFlag::NONE, KeyCode::KEY_2, ModifierFlag::OPTION_R | ModifierFlag::NONE</autogen>
+  </item>
+</root>


### PR DESCRIPTION
It's added in the application section: "Only for Microsoft Remote Desktop". 

This tool assume we use a french PC keyboard on the mac, so the key changes are different than the remapping you would expect in a classical remote desktop application. You can read more here: http://www.e-gaulue.com/en/2015/02/26/mac-get-rid-of-keyboard-foreign-layout-troubles-with-microsoft-remote-desktop/.

The  French common A1314 keyboard is made. I know lots of people in other countries complain about the keyboard support in their language for this app.