### PR TITLE
Added support for Wine to block pc style mappings.

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -45,6 +45,7 @@
     <equal>org.virtualbox.app.VirtualBoxVM</equal>
     <prefix>com.vmware.proxyApp.</prefix>
     <prefix>com.parallels.winapp.</prefix>
+    <prefix>org.winehq.wine</prefix>
   </appdef>
 
   <appdef>

--- a/src/core/server/Resources/replacementdef.xml
+++ b/src/core/server/Resources/replacementdef.xml
@@ -258,7 +258,7 @@
   <replacementdef>
     <replacementname>PC_STYLE_BINDINGS_IGNORE_APPS_DESCRIPTION</replacementname>
     <replacementvalue>
-      (Except in Virtual Machine, RDC, VNC, TeamViewer, EMACS, TERMINAL, X11, Citrix Viewer)
+      (Except in Virtual Machine, RDC, VNC, TeamViewer, EMACS, TERMINAL, X11, Citrix Viewer, Wine)
     </replacementvalue>
   </replacementdef>
 


### PR DESCRIPTION
Wine is a PC emulator for mac and is a virtual machine in a sense.  Wine will support PC commands by default and do not need to be switched to Mac commands.