### PR TITLE
Pass through ⌃X ⌃X in Emacs Control+X mode

### DIFF
--- a/src/core/server/Resources/include/checkbox/emacs_mode.xml
+++ b/src/core/server/Resources/include/checkbox/emacs_mode.xml
@@ -789,6 +789,7 @@
         <appendix>C-x u to Undo (Command+Z)</appendix>
         <appendix>C-x k to Close (Command+W)</appendix>
         <appendix>C-x C-c to Quit (Command+Q)</appendix>
+        <appendix>C-x C-x to Toggle Mark and Point</appendix>
         <appendix>C-x C-g to turn off Control+X Mode</appendix>
         <identifier vk_config="true">notsave.emacsmode_ex_controlX_core</identifier>
         {{ EMACS_MODE_C_X_EXTRA }}
@@ -803,6 +804,7 @@
           KeyCode::VK_CONFIG_FORCE_OFF_notsave_emacsmode_ex_controlX_core,
         </autogen>
         <autogen>__KeyToKey__ KeyCode::K, ModifierFlag::NONE,              KeyCode::W, ModifierFlag::COMMAND_L, KeyCode::VK_CONFIG_FORCE_OFF_notsave_emacsmode_ex_controlX_core</autogen>
+        <autogen>__KeyToKey__ KeyCode::X, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL | ModifierFlag::NONE, KeyCode::X, ModifierFlag::CONTROL_L, KeyCode::X, ModifierFlag::CONTROL_L, KeyCode::VK_CONFIG_FORCE_OFF_notsave_emacsmode_ex_controlX_core</autogen>
         <autogen>__KeyToKey__ KeyCode::G, MODIFIERFLAG_EITHER_LEFT_OR_RIGHT_CONTROL | ModifierFlag::NONE,                                      KeyCode::VK_CONFIG_FORCE_OFF_notsave_emacsmode_ex_controlX_core</autogen>
       </item>
       <item>

--- a/src/core/server/Resources/include/checkbox/emacs_mode.xml
+++ b/src/core/server/Resources/include/checkbox/emacs_mode.xml
@@ -789,7 +789,7 @@
         <appendix>C-x u to Undo (Command+Z)</appendix>
         <appendix>C-x k to Close (Command+W)</appendix>
         <appendix>C-x C-c to Quit (Command+Q)</appendix>
-        <appendix>C-x C-x to Toggle Mark and Point</appendix>
+        <appendix>C-x C-x to passthrough</appendix>
         <appendix>C-x C-g to turn off Control+X Mode</appendix>
         <identifier vk_config="true">notsave.emacsmode_ex_controlX_core</identifier>
         {{ EMACS_MODE_C_X_EXTRA }}


### PR DESCRIPTION
I use `DefaultKeyBindings.dict` alongside Karabiner to customize the Cocoa text system keybindings to more closely mirror Emacs behaviour. Many of these customizations can be found at 

https://gist.github.com/smilingpoplar/1728384

One of the most useful is ⌃X ⌃X which calls `swapWithMark:` Unfortunately Karabiner's Control+X mode ignores a second ⌃X issued when already in Control+X mode.

My patch handles a second ⌃X while already in Control+X mode by passing through both ⌃X keystrokes and ending Control+X mode. This allows `DefaultKeyBindings.dict` to handle the key combination and correctly simulate the Emacs `exchange-point-and-mark` command.