### PR TITLE
fix #723 exclude macVIM from pc style bindings

### DIFF
--- a/src/core/server/Resources/replacementdef.xml
+++ b/src/core/server/Resources/replacementdef.xml
@@ -238,15 +238,16 @@
   <replacementdef>
     <replacementname>PC_STYLE_BINDINGS_IGNORE_APPS</replacementname>
     <replacementvalue>
-      VIRTUALMACHINE,
-      REMOTEDESKTOPCONNECTION,
-      VNC,
-      TEAMVIEWER,
-      EMACS,
-      TERMINAL,
-      X11,
       CITRIX_XEN_APP_VIEWER,
+      EMACS,
+      REMOTEDESKTOPCONNECTION,
+      TEAMVIEWER,
+      TERMINAL,
+      VI,
+      VIRTUALMACHINE,
+      VNC,
       Wine,
+      X11,
     </replacementvalue>
   </replacementdef>
 


### PR DESCRIPTION
And alphabetical order on lists because I cannot avoid it.