### PR TITLE
Add Wireshark to the Qt application list.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Prepared settings have been updated.
 * Fixed issues:
-  * Some Qt apps might be crash when AXNotifier is enabled. (VirtualBox, LyX)
+  * Some Qt apps might be crash when AXNotifier is enabled. (LyX, VirtualBox, Wireshark)
 
 
 # Version 10.21.0

--- a/src/util/AXNotifier/Karabiner_AXNotifier/Classes/AXApplicationObserver.m
+++ b/src/util/AXNotifier/Karabiner_AXNotifier/Classes/AXApplicationObserver.m
@@ -150,10 +150,12 @@ observerCallback(AXObserverRef observer, AXUIElementRef element, CFStringRef not
   }
 
   // Qt apps will be crashed if observe.
+  // See https://bugreports.qt.io/browse/QTBUG-49907
   if (axNotifierPreferencesModel.disabledInQtApps) {
     if ([[[self.runningApplication bundleIdentifier] lowercaseString] hasPrefix:@"com.buhldata."] ||
         [[self.runningApplication bundleIdentifier] hasPrefix:@"org.virtualbox."] ||
         [[self.runningApplication bundleIdentifier] isEqualToString:@"org.lyx.lyx"] ||
+        [[[self.runningApplication bundleIdentifier] lowercaseString] isEqualToString:@"org.wireshark.wireshark"] ||
         false) {
       observable = NO;
     }


### PR DESCRIPTION
Add Wireshark to AXNotifier's list of non-observable Qt applications. See
https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=12876

Add a link to the Qt project bug.