### PR TITLE
hyperterm is now hyper

### DIFF
--- a/src/core/server/Resources/appdef.xml
+++ b/src/core/server/Resources/appdef.xml
@@ -33,6 +33,7 @@
     <equal>net.sourceforge.iTerm</equal>
     <equal>com.googlecode.iterm2</equal>
     <equal>co.zeit.hyperterm</equal>
+    <equal>co.zeit.hyper</equal>
   </appdef>
 
   <appdef>


### PR DESCRIPTION
Terminal app https://hyper.is/ has been renamed from hyperterm to just hyper, 
adding the new name, leaving the old one for backwards compatibility