### PR TITLE
add Czech and Slovak mapping for MacBook Air

### DIFF
--- a/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
+++ b/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
@@ -21,6 +21,7 @@
       <appendix>Option_R (AltGr) + - = * ... "key under esc" to ;</appendix>
       <identifier>remap.czech_win_shortcuts_air</identifier>
       <not>X11</not>
+      <autogen>__KeyToKey__ KeyCode::DANISH_DOLLAR, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::DOT, ModifierFlag::OPTION_R, KeyCode::DOT, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::COMMA, ModifierFlag::OPTION_R, KeyCode::COMMA, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::V, ModifierFlag::OPTION_R, KeyCode::KEY_2, ModifierFlag::OPTION_R</autogen>

--- a/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
+++ b/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
@@ -27,6 +27,8 @@
       <autogen>__KeyToKey__ KeyCode::V, ModifierFlag::OPTION_R, KeyCode::KEY_2, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::SEMICOLON, ModifierFlag::OPTION_R, KeyCode::KEY_4, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::SLASH, ModifierFlag::OPTION_R, KeyCode::KEY_8, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::BACKSLASH, ModifierFlag::SHIFT_R, KeyCode::QUOTE, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::BACKSLASH, ModifierFlag::SHIFT_L, KeyCode::QUOTE, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::A, ModifierFlag::OPTION_R, KeyCode::KEY_5, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::C, ModifierFlag::OPTION_R, KeyCode::KEY_7, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::X, ModifierFlag::OPTION_R, KeyCode::KEY_3, ModifierFlag::OPTION_R</autogen>

--- a/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
+++ b/src/core/server/Resources/include/checkbox/languages/czech_macbook_air.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>For Czech (MacBook Air)</name>
+    <item>
+      <name>Remap keyboard (symbol) shortcuts to standard Windows/Linux style</name>
+      <appendix></appendix>
+      <appendix>Remap keyboard shortcuts on czech keyboard layout to behave like in Windows with AltGr.</appendix>
+      <appendix>Recommended: remap your modifier keys under System Preferences-Keyboard-Modifier Keys</appendix>
+      <appendix>under Keyboard Tab</appendix>
+      <appendix>Notice: Disabled for X11 - you have to use xmodmap (use xev to get kb codes) under</appendix>
+      <appendix>xterm in X11</appendix>
+      <appendix></appendix>
+      <appendix>Option_R (AltGr) + V = @ ... Option_R (AltGr) + C = &amp;</appendix>
+      <appendix>Option_R (AltGr) + W = | ... Option_R (AltGr) + E = €</appendix>
+      <appendix>Option_R (AltGr) + B = { ... Option_R (AltGr) + N = }</appendix>
+      <appendix>Option_R (AltGr) + F = [ ... Option_R (AltGr) + G = ]</appendix>
+      <appendix>Option_R (AltGr) + ů = $ ... Option_R (AltGr) + X = #</appendix>
+      <appendix>Option_R (AltGr) + A = ~ ... Option_R (AltGr) + Q = \</appendix>
+      <appendix>Option_R (AltGr) + , = &lt; ... Option_R (AltGr) + . = &gt;</appendix>
+      <appendix>Option_R (AltGr) + - = * ... "key under esc" to ;</appendix>
+      <identifier>remap.czech_win_shortcuts_air</identifier>
+      <not>X11</not>
+      <autogen>__KeyToKey__ KeyCode::DOT, ModifierFlag::OPTION_R, KeyCode::DOT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::COMMA, ModifierFlag::OPTION_R, KeyCode::COMMA, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::V, ModifierFlag::OPTION_R, KeyCode::KEY_2, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::SEMICOLON, ModifierFlag::OPTION_R, KeyCode::KEY_4, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::SLASH, ModifierFlag::OPTION_R, KeyCode::KEY_8, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::A, ModifierFlag::OPTION_R, KeyCode::KEY_5, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::C, ModifierFlag::OPTION_R, KeyCode::KEY_7, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::X, ModifierFlag::OPTION_R, KeyCode::KEY_3, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::F, ModifierFlag::OPTION_R, KeyCode::BRACKET_LEFT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::G, ModifierFlag::OPTION_R, KeyCode::BRACKET_RIGHT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::E, ModifierFlag::OPTION_R, KeyCode::R, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::B, ModifierFlag::OPTION_R, KeyCode::KEY_9, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::N, ModifierFlag::OPTION_R, KeyCode::KEY_0, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::W, ModifierFlag::OPTION_R, KeyCode::RUSSIAN_TILDE, ModifierFlag::SHIFT_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::Q, ModifierFlag::OPTION_R, KeyCode::RUSSIAN_TILDE</autogen>
+      <!-- only on Internal Apple keyboard -->
+      <!-- because on Apple internal is swapped keycode with "key in front of Shift_L" and "key under escape" -->
+      <block>
+        <device_only>DeviceVendor::APPLE_COMPUTER,DeviceProduct::APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0237</device_only>
+        <autogen>__KeyToKey__ KeyCode::OPTION_R, KeyCode::CONTROL_R</autogen>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_PARAGRAPH, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
+      </block>
+      <!-- only on external keyboard -->
+      <block>
+        <device_not>DeviceVendor::APPLE_COMPUTER,DeviceProduct::APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0237</device_not>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_TILDE, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_PARAGRAPH, KeyCode::RUSSIAN_TILDE</autogen>
+      </block>
+    </item>
+  </item>
+</root>

--- a/src/core/server/Resources/include/checkbox/languages/slovak.xml
+++ b/src/core/server/Resources/include/checkbox/languages/slovak.xml
@@ -21,6 +21,7 @@
       <appendix>Option_R (AltGr) + - = * ... "key under esc" to ;</appendix>
       <identifier>remap.slovak_win_shortcuts_air</identifier>
       <not>X11</not>
+      <autogen>__KeyToKey__ KeyCode::DANISH_DOLLAR, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::DOT, ModifierFlag::OPTION_R, KeyCode::DOT, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::COMMA, ModifierFlag::OPTION_R, KeyCode::COMMA, ModifierFlag::OPTION_R</autogen>
       <autogen>__KeyToKey__ KeyCode::V, ModifierFlag::OPTION_R, KeyCode::KEY_2, ModifierFlag::OPTION_R</autogen>

--- a/src/core/server/Resources/include/checkbox/languages/slovak.xml
+++ b/src/core/server/Resources/include/checkbox/languages/slovak.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<root>
+  <item>
+    <name>For Slovak (MacBook Air)</name>
+    <item>
+      <name>Remap keyboard (symbol) shortcuts to standard Windows/Linux style</name>
+      <appendix></appendix>
+      <appendix>Remap keyboard shortcuts on slovak keyboard layout to behave like in Windows with AltGr.</appendix>
+      <appendix>Recommended: remap your modifier keys under System Preferences-Keyboard-Modifier Keys</appendix>
+      <appendix>under Keyboard Tab</appendix>
+      <appendix>Notice: Disabled for X11 - you have to use xmodmap (use xev to get kb codes) under</appendix>
+      <appendix>xterm in X11</appendix>
+      <appendix></appendix>
+      <appendix>Option_R (AltGr) + V = @ ... Option_R (AltGr) + C = &amp;</appendix>
+      <appendix>Option_R (AltGr) + W = | ... Option_R (AltGr) + E = €</appendix>
+      <appendix>Option_R (AltGr) + B = { ... Option_R (AltGr) + N = }</appendix>
+      <appendix>Option_R (AltGr) + F = [ ... Option_R (AltGr) + G = ]</appendix>
+      <appendix>Option_R (AltGr) + ů = $ ... Option_R (AltGr) + X = #</appendix>
+      <appendix>Option_R (AltGr) + A = ~ ... Option_R (AltGr) + Q = \</appendix>
+      <appendix>Option_R (AltGr) + , = &lt; ... Option_R (AltGr) + . = &gt;</appendix>
+      <appendix>Option_R (AltGr) + - = * ... "key under esc" to ;</appendix>
+      <identifier>remap.slovak_win_shortcuts_air</identifier>
+      <not>X11</not>
+      <autogen>__KeyToKey__ KeyCode::DOT, ModifierFlag::OPTION_R, KeyCode::DOT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::COMMA, ModifierFlag::OPTION_R, KeyCode::COMMA, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::V, ModifierFlag::OPTION_R, KeyCode::KEY_2, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::SEMICOLON, ModifierFlag::OPTION_R, KeyCode::KEY_4, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::SLASH, ModifierFlag::OPTION_R, KeyCode::KEY_8, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::A, ModifierFlag::OPTION_R, KeyCode::KEY_5, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::C, ModifierFlag::OPTION_R, KeyCode::KEY_7, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::X, ModifierFlag::OPTION_R, KeyCode::KEY_3, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::F, ModifierFlag::OPTION_R, KeyCode::BRACKET_LEFT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::G, ModifierFlag::OPTION_R, KeyCode::BRACKET_RIGHT, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::E, ModifierFlag::OPTION_R, KeyCode::R, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::B, ModifierFlag::OPTION_R, KeyCode::KEY_9, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::N, ModifierFlag::OPTION_R, KeyCode::KEY_0, ModifierFlag::OPTION_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::W, ModifierFlag::OPTION_R, KeyCode::RUSSIAN_TILDE, ModifierFlag::SHIFT_R</autogen>
+      <autogen>__KeyToKey__ KeyCode::Q, ModifierFlag::OPTION_R, KeyCode::RUSSIAN_TILDE</autogen>
+      <!-- only on Internal Apple keyboard -->
+      <!-- because on Apple internal is swapped keycode with "key in front of Shift_L" and "key under escape" -->
+      <block>
+        <device_only>DeviceVendor::APPLE_COMPUTER,DeviceProduct::APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0237</device_only>
+        <autogen>__KeyToKey__ KeyCode::OPTION_R, KeyCode::CONTROL_R</autogen>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_PARAGRAPH, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
+      </block>
+      <!-- only on external keyboard -->
+      <block>
+        <device_not>DeviceVendor::APPLE_COMPUTER,DeviceProduct::APPLE_INTERNAL_KEYBOARD_TRACKPAD_0x0237</device_not>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_TILDE, KeyCode::SEMICOLON, ModifierFlag::OPTION_R</autogen>
+        <autogen>__KeyToKey__ KeyCode::RUSSIAN_PARAGRAPH, KeyCode::RUSSIAN_TILDE</autogen>
+      </block>
+    </item>
+  </item>
+</root>


### PR DESCRIPTION
* OS X version: El Capitan
* Karabiner version: 10.22.0
* Your Mac hardware: MacBook Air 13, Early 2015
* Your keyboard hardware: MacBook Air keyboard

I made derivate of czech.xml. The original czech.xml is based on CONTROL_R which is not available on MacBook Air. I changed the CONTROL_R to Option_R. The Option_R is common mapping also on Windows. The new file has name czech_macbook_air.xml.

Then I made copy of this file and stored it under slovak.xml. While Czech and Slovak are very close there are some differences and I recommend to keep the file separate for corrections of mapping in future.

Please review the suggested change. I'll be happy for any feedback. Thank you.