### PR TITLE
Suggest Karabiner Elements for MacOS Sierra users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Karabiner is a powerful utility for keyboard customization.
 
 Prior to version 9.3.0, Karabiner was called *KeyRemap4MacBook*.
 
+**Karabiner does not work on MacOS Sierra (10.12)**. Sierra users should instead try [Karabiner Elements](https://github.com/tekezo/Karabiner-Elements), which supports a useful subset of Karabiner functionality.
+
 Useful links
 ------------
 
@@ -30,8 +32,9 @@ $ curl -L -O https://pqrs.org/latest/karabiner-latest.dmg
 System requirements
 -------------------
 
-Karabiner works for all Mac products, including the MacBook series, iMac, Mac mini, and Mac Pro, with the requirement that the product runs OS X 10.9 (Mavericks) or higher.
+Karabiner works for all Mac products, including the MacBook series, iMac, Mac mini, and Mac Pro, with the requirement that the product runs OS X 10.9 (Mavericks) or higher, up until MacOS 10.12 (Sierra), which is not supported.
 
+* If you require Karabiner for MacOS 10.12, please use [Karabiner Elements](https://github.com/tekezo/Karabiner-Elements).
 * If you require Karabiner for OS X 10.6 - 10.8, please use KeyRemap4MacBook 8.4.0.
 * If you require Karabiner for OS X 10.4 - 10.5, please use KeyRemap4MacBook 5.1.0.
 


### PR DESCRIPTION
In https://github.com/tekezo/Karabiner/issues/660#issuecomment-231931573, @tekezo mentions Karabiner Elements is the only available option for Sierra users. 

This adds that information to the readme. 